### PR TITLE
Divide into more sections, and assorted cleanup

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -1018,7 +1018,7 @@ to build the recipe."
       (dolist (key symbol-keys)
         (let ((val (plist-get rest key)))
           (when val
-            (cl-assert (symbolp val) nil "%s must be a list but is %S" key val))))
+            (cl-assert (symbolp val) nil "%s must be a symbol but is %S" key val))))
       (dolist (key list-keys)
         (let ((val (plist-get rest key)))
           (when val

--- a/package-build.el
+++ b/package-build.el
@@ -97,10 +97,9 @@ This must be a version which supports the \"-k\" option."
 (defcustom package-build-timeout-secs 600
   "Wait this many seconds for external processes to complete.
 
-If an external process takes longer than
-`package-build-timeout-secs' seconds to complete, the process is
-terminated.  The `package-build-timeout-secs' variable will only
-have an effect if `package-build-timeout-executable' is not nil."
+If an external process takes longer than specified here to
+complete, then it is terminated.  This only has an effect
+if `package-build-timeout-executable' is non-nil."
   :group 'package-build
   :type 'number)
 
@@ -152,7 +151,8 @@ function for access to this function")
   "Default value for :files attribute in recipes.")
 
 (defun package-build--message (format-string &rest args)
-  "Log a message using FORMAT-STRING and ARGS as per `message'."
+  "Behave like `message' if `package-build-verbose' is non-nil.
+Otherwise do nothing."
   (when package-build-verbose
     (apply 'message format-string args)))
 
@@ -1497,7 +1497,7 @@ Returns the archive entry for the package."
     (package-build-dump-archive-contents)))
 
 (defun package-build-recipe-alist ()
-  "Retun the list of avalailable packages."
+  "Return the list of available packages."
   (unless package-build--recipe-alist-initialized
     (setq package-build--recipe-alist (package-build--read-recipes-ignore-errors)
           package-build--recipe-alist-initialized t))

--- a/package-build.el
+++ b/package-build.el
@@ -1530,6 +1530,7 @@ If FILE-NAME is not specified, the default archive-contents file is used."
 ;; Local Variables:
 ;; coding: utf-8
 ;; checkdoc-minor-mode: 1
+;; indent-tabs-mode: nil
 ;; End:
 
 ;;; package-build.el ends here

--- a/package-build.el
+++ b/package-build.el
@@ -1364,29 +1364,6 @@ Returns the archive entry for the package."
           (package-build--archive-entry pkg-info 'tar))
       (delete-directory tmp-dir t nil))))
 
-
-;; In future we should provide a hook, and perform this step in a
-;; separate package.  Note also that it would be straightforward to
-;; generate the SVG ourselves, which would save the network overhead.
-(defun package-build--write-melpa-badge-image (package-name version target-dir)
-  (let ((badge-url (concat "https://img.shields.io/badge/"
-                           (if package-build-stable "melpa stable" "melpa")
-                           "-"
-                           (url-hexify-string version)
-                           "-"
-                           (if package-build-stable "3e999f" "922793")
-                           ".svg"))
-        (badge-filename (expand-file-name (concat package-name "-badge.svg")
-                                          target-dir)))
-    (if (executable-find "curl")
-        ;; Not strictly needed, but less likely to break due to gnutls issues
-        (shell-command (mapconcat #'identity
-                                  (list "curl" "-f" "-o"
-                                        (shell-quote-argument badge-filename)
-                                        (shell-quote-argument badge-url))
-                                  " "))
-      (package-build--url-copy-file badge-url badge-filename t))))
-
 ;;; Helpers for recipe authors
 
 (defvar package-build-minor-mode-map
@@ -1582,6 +1559,31 @@ If FILE-NAME is not specified, the default archive-contents file is used."
   (interactive)
   (with-temp-file file
     (insert (json-encode (package-build--archive-alist-for-json)))))
+
+;;; Melpa Batches
+
+;; In future we should provide a hook, and perform this step in a
+;; separate package.  Note also that it would be straightforward to
+;; generate the SVG ourselves, which would save the network overhead.
+
+(defun package-build--write-melpa-badge-image (package-name version target-dir)
+  (let ((badge-url (concat "https://img.shields.io/badge/"
+                           (if package-build-stable "melpa stable" "melpa")
+                           "-"
+                           (url-hexify-string version)
+                           "-"
+                           (if package-build-stable "3e999f" "922793")
+                           ".svg"))
+        (badge-filename (expand-file-name (concat package-name "-badge.svg")
+                                          target-dir)))
+    (if (executable-find "curl")
+        ;; Not strictly needed, but less likely to break due to gnutls issues
+        (shell-command (mapconcat #'identity
+                                  (list "curl" "-f" "-o"
+                                        (shell-quote-argument badge-filename)
+                                        (shell-quote-argument badge-url))
+                                  " "))
+      (package-build--url-copy-file badge-url badge-filename t))))
 
 (provide 'package-build)
 

--- a/package-build.el
+++ b/package-build.el
@@ -162,7 +162,6 @@ function for access to this function")
   "Remove trailing whitespace from `STR'."
   (replace-regexp-in-string "[ \t\n\r]+$" "" str))
 
-
 (defun package-build--valid-version (str &optional regexp)
   "Apply to STR the REGEXP if defined, \
 then pass the string to `version-to-list' and return the result, \
@@ -450,7 +449,6 @@ A number as third arg means request confirmation if NEWNAME already exists."
                (package-build--expand-source-file-list dir config))
         (or (package-build--find-parse-time-newest "Last Changed Date: \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)" bound)
             (error "No valid timestamps found!"))))))
-
 
 (defun package-build--cvs-repo (dir)
   "Get the current CVS root and repository for DIR.
@@ -743,7 +741,6 @@ Optionally PRETTY-PRINT the data."
          "--exclude=.hg"
          (or (mapcar (lambda (fn) (concat dir "/" fn)) files) (list dir))))
 
-
 (defun package-build--find-package-commentary (file-path)
   "Get commentary section from FILE-PATH."
   (when (file-exists-p file-path)
@@ -970,7 +967,6 @@ to build the recipe."
            when pkg-info
            collect pkg-info))
 
-
 (defun package-build-expand-file-specs (dir specs &optional subdir allow-empty)
   "In DIR, expand SPECS, optionally under SUBDIR.
 The result is a list of (SOURCE . DEST), where SOURCE is a source
@@ -1008,7 +1004,6 @@ for ALLOW-EMPTY to prevent this error."
     (when (and (null lst) (not allow-empty))
       (error "No matching file(s) found in %s: %s" dir specs))
     lst))
-
 
 (defun package-build--config-file-list (config)
   "Get the :files spec from CONFIG, or return `package-build-default-files-spec'."
@@ -1094,7 +1089,6 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
     (package-build--message "%s => %s" file newname)
     (copy-directory file newname))))
 
-
 (defun package-build--package-name-completing-read ()
   "Prompt for a package name, returning a symbol."
   (intern (completing-read "Package: " (package-build-recipe-alist))))
@@ -1156,8 +1150,8 @@ and a cl struct in Emacs HEAD.  This wrapper normalises the results."
                        (file-newer-than-file-p package-file package-build--this-file)))
           (cl-return t))))))
 
-
 ;;; Public interface
+
 ;;;###autoload
 (defun package-build-archive (name)
   "Build a package archive for package NAME."
@@ -1412,7 +1406,6 @@ Returns the archive entry for the package."
        nil))))
 
 
-
 ;;;###autoload
 (defun package-build-all ()
   "Build all packages in the `package-build-recipe-alist'."
@@ -1482,7 +1475,6 @@ If FILE-NAME is not specified, the default archive-contents file is used."
         (add-to-list 'entries new)))))
 
 
-
 ;;; Exporting data as json
 
 (defun package-build-recipe-alist-as-json (file-name)
@@ -1524,7 +1516,6 @@ If FILE-NAME is not specified, the default archive-contents file is used."
   (with-temp-file file-name
     (insert (json-encode (package-build--archive-alist-for-json)))))
 
-
 (provide 'package-build)
 
 ;; Local Variables:
@@ -1532,5 +1523,4 @@ If FILE-NAME is not specified, the default archive-contents file is used."
 ;; checkdoc-minor-mode: 1
 ;; indent-tabs-mode: nil
 ;; End:
-
 ;;; package-build.el ends here

--- a/package-build.el
+++ b/package-build.el
@@ -914,8 +914,8 @@ If PKG-INFO is nil, an empty one is created."
         (requires (aref pkg-info 1))
         (desc (or (aref pkg-info 2) "No description available."))
         (version (aref pkg-info 3))
-        (extras (when (> (length pkg-info) 4)
-                  (aref pkg-info 4))))
+        (extras (and (> (length pkg-info) 4)
+                     (aref pkg-info 4))))
     (cons name
           (vector (version-to-list version)
                   requires
@@ -1559,7 +1559,8 @@ If FILE-NAME is not specified, the default archive-contents file is used."
         (deps (elt info 1))
         (desc (elt info 2))
         (type (elt info 3))
-        (props (when (> (length info) 4) (elt info 4))))
+        (props (and (> (length info) 4)
+                    (elt info 4))))
     (list :ver ver
           :deps (cl-mapcan (lambda (dep)
                              (list (package-build--sym-to-keyword (car dep))

--- a/package-build.el
+++ b/package-build.el
@@ -156,11 +156,11 @@ function for access to this function")
   (when package-build-verbose
     (apply 'message format-string args)))
 
-(defun package-build--slurp-file (file-name)
-  "Return the contents of FILE-NAME as a string, or nil if no such file exists."
-  (when (file-exists-p file-name)
+(defun package-build--slurp-file (file)
+  "Return the contents of FILE as a string, or nil if no such file exists."
+  (when (file-exists-p file)
     (with-temp-buffer
-      (insert-file-contents file-name)
+      (insert-file-contents file)
       (buffer-substring-no-properties (point-min) (point-max)))))
 
 (defun package-build--string-rtrim (str)
@@ -765,10 +765,10 @@ Optionally PRETTY-PRINT the data."
     (princ ";; Local Variables:\n;; no-byte-compile: t\n;; End:\n"
            (current-buffer))))
 
-(defun package-build--read-from-file (file-name)
-  "Read and return the Lisp data stored in FILE-NAME, or nil if no such file exists."
-  (when (file-exists-p file-name)
-    (car (read-from-string (package-build--slurp-file file-name)))))
+(defun package-build--read-from-file (file)
+  "Read and return the Lisp data stored in FILE, or nil if no such file exists."
+  (when (file-exists-p file)
+    (car (read-from-string (package-build--slurp-file file)))))
 
 (defun package-build--create-tar (file dir &optional files)
   "Create a tar FILE containing the contents of DIR, or just FILES if non-nil."
@@ -1515,12 +1515,12 @@ Returns the archive entry for the package."
   (interactive)
   (setq package-build--recipe-alist-initialized nil))
 
-(defun package-build-dump-archive-contents (&optional file-name pretty-print)
-  "Dump the list of built packages to FILE-NAME.
+(defun package-build-dump-archive-contents (&optional file pretty-print)
+  "Dump the list of built packages to FILE.
 
 If FILE-NAME is not specified, the default archive-contents file is used."
   (package-build--dump (cons 1 (package-build--archive-entries))
-                       (or file-name
+                       (or file
                            (expand-file-name "archive-contents"
                                              package-build-archive-dir))
                        pretty-print))
@@ -1544,10 +1544,10 @@ If FILE-NAME is not specified, the default archive-contents file is used."
 
 ;;; Exporting data as json
 
-(defun package-build-recipe-alist-as-json (file-name)
-  "Dump the recipe list to FILE-NAME as json."
+(defun package-build-recipe-alist-as-json (file)
+  "Dump the recipe list to FILE as json."
   (interactive)
-  (with-temp-file file-name
+  (with-temp-file file
     (insert (json-encode (package-build-recipe-alist)))))
 
 (defun package-build--sym-to-keyword (s)
@@ -1577,10 +1577,10 @@ If FILE-NAME is not specified, the default archive-contents file is used."
                      (package-build--pkg-info-for-json (cdr entry))))
              (package-build-archive-alist)))
 
-(defun package-build-archive-alist-as-json (file-name)
-  "Dump the build packages list to FILE-NAME as json."
+(defun package-build-archive-alist-as-json (file)
+  "Dump the build packages list to FILE as json."
   (interactive)
-  (with-temp-file file-name
+  (with-temp-file file
     (insert (json-encode (package-build--archive-alist-for-json)))))
 
 (provide 'package-build)

--- a/package-build.el
+++ b/package-build.el
@@ -1588,7 +1588,6 @@ If FILE-NAME is not specified, the default archive-contents file is used."
 
 (defun package-build-archive-alist-as-json (file)
   "Dump the build packages list to FILE as json."
-  (interactive)
   (with-temp-file file
     (insert (json-encode (package-build--archive-alist-for-json)))))
 

--- a/package-build.el
+++ b/package-build.el
@@ -181,7 +181,9 @@ or nil if the version cannot be parsed."
   ;; when stored in the archive-contents
   (let* ((s (substring-no-properties str))
          (time (date-to-time
-                (if (string-match "^\\([0-9]\\{4\\}\\)/\\([0-9]\\{2\\}\\)/\\([0-9]\\{2\\}\\) \\([0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\)$" s)
+                (if (string-match "\
+^\\([0-9]\\{4\\}\\)/\\([0-9]\\{2\\}\\)/\\([0-9]\\{2\\}\\) \
+\\([0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\)$" s)
                     (concat (match-string 1 s) "-" (match-string 2 s) "-"
                             (match-string 3 s) " " (match-string 4 s))
                   s))))
@@ -405,8 +407,10 @@ A number as third arg means request confirmation if NEWNAME already exists."
         (apply 'package-build--run-process
                dir "darcs" "changes" "--max-count" "1"
                (package-build--expand-source-file-list dir config))
-        (package-build--find-parse-time
-         "\\([a-zA-Z]\\{3\\} [a-zA-Z]\\{3\\} \\( \\|[0-9]\\)[0-9] [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\} [A-Za-z]\\{3\\} [0-9]\\{4\\}\\)")))))
+        (package-build--find-parse-time "\
+\\([a-zA-Z]\\{3\\} [a-zA-Z]\\{3\\} \
+\\( \\|[0-9]\\)[0-9] [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\} \
+[A-Za-z]\\{3\\} [0-9]\\{4\\}\\)")))))
 
 (defun package-build--fossil-repo (dir)
   "Get the current fossil repo for DIR."
@@ -431,8 +435,9 @@ A number as third arg means request confirmation if NEWNAME already exists."
           (package-build--run-process dir "fossil" "clone" repo "repo.fossil")
           (package-build--run-process dir "fossil" "open" "repo.fossil")))
         (package-build--run-process dir "fossil" "timeline" "-n" "1" "-t" "ci")
-        (or (package-build--find-parse-time
-             "=== \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} ===\n[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\) ")
+        (or (package-build--find-parse-time "\
+=== \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} ===\n\
+[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\) ")
             (error "No valid timestamps found!"))))))
 
 (defun package-build--svn-repo (dir)
@@ -471,7 +476,10 @@ A number as third arg means request confirmation if NEWNAME already exists."
           (package-build--run-process nil "svn" "checkout" repo dir)))
         (apply 'package-build--run-process dir "svn" "info"
                (package-build--expand-source-file-list dir config))
-        (or (package-build--find-parse-time-newest "Last Changed Date: \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)" bound)
+        (or (package-build--find-parse-time-newest "\
+Last Changed Date: \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
+[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)"
+             bound)
             (error "No valid timestamps found!"))))))
 
 (defun package-build--cvs-repo (dir)
@@ -593,8 +601,9 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
         (apply 'package-build--run-process
                dir "git" "log" "--first-parent" "-n1" "--pretty=format:'\%ci'"
                (package-build--expand-source-file-list dir config))
-        (package-build--find-parse-time
-         "\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))))
+        (package-build--find-parse-time "\
+\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
+[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))))
 
 (defun package-build--update-git-to-ref (dir ref)
   "Update the git repo in DIR so that HEAD is REF."
@@ -660,8 +669,9 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
             (package-version-join (car tag-version)))
         (apply 'package-build--run-process dir "bzr" "log" "-l1"
                (package-build--expand-source-file-list dir config))
-        (package-build--find-parse-time
-         "\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))))
+        (package-build--find-parse-time "\
+\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
+[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))))
 
 (defun package-build--hg-repo (dir)
   "Get the current hg repo for DIR."
@@ -713,8 +723,9 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
         (apply 'package-build--run-process
                dir "hg" "log" "--style" "compact" "-l1"
                (package-build--expand-source-file-list dir config))
-        (package-build--find-parse-time
-         "\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} [0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))))
+        (package-build--find-parse-time "\
+\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
+[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))))
 
 (defun package-build--dump (data file &optional pretty-print)
   "Write DATA to FILE as a Lisp sexp.

--- a/package-build.el
+++ b/package-build.el
@@ -348,9 +348,9 @@ A number as third arg means request confirmation if NEWNAME already exists."
 
 (defun package-build--grab-wiki-file (filename)
   "Download FILENAME from emacswiki, returning its last-modified time."
-  (let* ((download-url
-          (format "https://www.emacswiki.org/emacs/download/%s" filename))
-         headers)
+  (let ((download-url
+         (format "https://www.emacswiki.org/emacs/download/%s" filename))
+        headers)
     (package-build--with-wiki-rate-limit
      (setq headers (package-build--url-copy-file download-url filename t)))
     (when (zerop (nth 7 (file-attributes filename)))
@@ -613,17 +613,17 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
 
 (defun package-build--checkout-github (name config dir)
   "Check package NAME with config CONFIG out of github into DIR."
-  (let* ((url (format "https://github.com/%s.git" (plist-get config :repo))))
+  (let ((url (format "https://github.com/%s.git" (plist-get config :repo))))
     (package-build--checkout-git name (plist-put (copy-sequence config) :url url) dir)))
 
 (defun package-build--checkout-gitlab (name config dir)
   "Check package NAME with config CONFIG out of gitlab into DIR."
-  (let* ((url (format "https://gitlab.com/%s.git" (plist-get config :repo))))
+  (let ((url (format "https://gitlab.com/%s.git" (plist-get config :repo))))
     (package-build--checkout-git name (plist-put (copy-sequence config) :url url) dir)))
 
 (defun package-build--checkout-bitbucket (name config dir)
   "Check package NAME with config CONFIG out of bitbucket into DIR."
-  (let* ((url (format "https://bitbucket.com/%s" (plist-get config :repo))))
+  (let ((url (format "https://bitbucket.com/%s" (plist-get config :repo))))
     (package-build--checkout-hg name (plist-put (copy-sequence config) :url url) dir)))
 
 (defun package-build--bzr-expand-repo (repo)
@@ -902,20 +902,20 @@ Optionally PRETTY-PRINT the data."
 (defun package-build--merge-package-info (pkg-info name version)
   "Return a version of PKG-INFO updated with NAME, VERSION and info from CONFIG.
 If PKG-INFO is nil, an empty one is created."
-  (let* ((merged (or (copy-sequence pkg-info)
-                     (vector name nil "No description available." version))))
+  (let ((merged (or (copy-sequence pkg-info)
+                    (vector name nil "No description available." version))))
     (aset merged 0 name)
     (aset merged 3 version)
     merged))
 
 (defun package-build--archive-entry (pkg-info type)
   "Return the archive-contents cons cell for PKG-INFO and TYPE."
-  (let* ((name (intern (aref pkg-info 0)))
-         (requires (aref pkg-info 1))
-         (desc (or (aref pkg-info 2) "No description available."))
-         (version (aref pkg-info 3))
-         (extras (when (> (length pkg-info) 4)
-                   (aref pkg-info 4))))
+  (let ((name (intern (aref pkg-info 0)))
+        (requires (aref pkg-info 1))
+        (desc (or (aref pkg-info 2) "No description available."))
+        (version (aref pkg-info 3))
+        (extras (when (> (length pkg-info) 4)
+                  (aref pkg-info 4))))
     (cons name
           (vector (version-to-list version)
                   requires
@@ -1555,11 +1555,11 @@ If FILE-NAME is not specified, the default archive-contents file is used."
 
 (defun package-build--pkg-info-for-json (info)
   "Convert INFO into a data structure which will serialize to JSON in the desired shape."
-  (let* ((ver (elt info 0))
-         (deps (elt info 1))
-         (desc (elt info 2))
-         (type (elt info 3))
-         (props (when (> (length info) 4) (elt info 4))))
+  (let ((ver (elt info 0))
+        (deps (elt info 1))
+        (desc (elt info 2))
+        (type (elt info 3))
+        (props (when (> (length info) 4) (elt info 4))))
     (list :ver ver
           :deps (cl-mapcan (lambda (dep)
                              (list (package-build--sym-to-keyword (car dep))

--- a/package-build.el
+++ b/package-build.el
@@ -194,8 +194,8 @@ or nil if the version cannot be parsed."
   "Find REGEXP in current buffer and format as a time-based version string.
 An optional second argument bounds the search; it is a buffer
 position.  The match found must not end after that position."
-  (package-build--parse-time (and (re-search-backward regexp bound t)
-                                  (match-string-no-properties 1))))
+  (and (re-search-backward regexp bound t)
+       (package-build--parse-time (match-string-no-properties 1))))
 
 (defun package-build--find-parse-time-newest (regexp &optional bound)
   "Find REGEXP in current buffer and format as a time-based version string.
@@ -203,8 +203,7 @@ An optional second argument bounds the search; it is a buffer
 position.  The match found must not end after that position."
   (save-match-data
     (let (cur matches)
-      (while (setq cur (ignore-errors
-                         (package-build--find-parse-time regexp bound)))
+      (while (setq cur (package-build--find-parse-time regexp bound))
         (push cur matches))
       (car (nreverse (sort matches 'string<))))))
 

--- a/package-build.el
+++ b/package-build.el
@@ -190,26 +190,26 @@ or nil if the version cannot be parsed."
     (concat (format-time-string "%Y%m%d." time)
             (format "%d" (string-to-number (format-time-string "%H%M" time))))))
 
-(defun package-build--find-parse-time (regex &optional bound)
-  "Find REGEX in current buffer and format as a time-based version string.
+(defun package-build--find-parse-time (regexp &optional bound)
+  "Find REGEXP in current buffer and format as a time-based version string.
 An optional second argument bounds the search; it is a buffer
 position.  The match found must not end after that position."
-  (package-build--parse-time (and (re-search-backward regex bound t)
+  (package-build--parse-time (and (re-search-backward regexp bound t)
                                   (match-string-no-properties 1))))
 
-(defun package-build--find-parse-time-newest (regex &optional bound)
-  "Find REGEX in current buffer and format as a time-based version string.
+(defun package-build--find-parse-time-newest (regexp &optional bound)
+  "Find REGEXP in current buffer and format as a time-based version string.
 An optional second argument bounds the search; it is a buffer
 position.  The match found must not end after that position."
   (save-match-data
     (let (cur matches)
       (while (setq cur (ignore-errors
-                         (package-build--find-parse-time regex bound)))
+                         (package-build--find-parse-time regexp bound)))
         (push cur matches))
       (car (nreverse (sort matches 'string<))))))
 
-(defun package-build--find-version-newest (regex &optional bound)
-  "Find the newest version matching REGEX before point.
+(defun package-build--find-version-newest (regexp &optional bound)
+  "Find the newest version matching REGEXP before point.
 An optional second argument bounds the search; it is a buffer
 position.  The match found must not before after that position."
   (let ((tags (split-string
@@ -223,8 +223,8 @@ position.  The match found must not before after that position."
                  ;; wrongly as (1 -4 4 -4 5), so we set
                  ;; `version-separator' to "_" below and run again.
                  (lambda (tag)
-                   (when (package-build--valid-version tag regex)
-                     (list (package-build--valid-version tag regex) tag)))
+                   (when (package-build--valid-version tag regexp)
+                     (list (package-build--valid-version tag regexp) tag)))
                  tags)
                 (mapcar
                  ;; Check for valid versions again, this time using
@@ -237,8 +237,8 @@ position.  The match found must not before after that position."
                  ;; `version-list-<'.
                  (lambda (tag)
                    (let ((version-separator "_"))
-                     (when (package-build--valid-version tag regex)
-                       (list (package-build--valid-version tag regex) tag))))
+                     (when (package-build--valid-version tag regexp)
+                       (list (package-build--valid-version tag regexp) tag))))
                  tags)))
     (setq tags (cl-remove-if nil tags))
     ;; Returns a list like ((0 1) ("v0.1")); the first element is used
@@ -267,13 +267,13 @@ Output is written to the current buffer."
           (error "Command '%s' exited with non-zero status %d: %s"
                  argv exit-code (buffer-string))))))
 
-(defun package-build--run-process-match (regex dir prog &rest args)
-  "Run PROG with args and return the first match for REGEX in its output.
+(defun package-build--run-process-match (regexp dir prog &rest args)
+  "Run PROG with args and return the first match for REGEXP in its output.
 PROG is run in DIR, or if that is nil in `default-directory'."
   (with-temp-buffer
     (apply 'package-build--run-process dir prog args)
     (goto-char (point-min))
-    (re-search-forward regex)
+    (re-search-forward regexp)
     (match-string-no-properties 1)))
 
 (defun package-build-checkout (package-name config working-dir)

--- a/package-build.el
+++ b/package-build.el
@@ -73,12 +73,12 @@
   :type 'string)
 
 (defcustom package-build-verbose t
-  "When non-nil, `package-build' feels free to print information about its progress."
+  "When non-nil, then print additional progress information."
   :group 'package-build
   :type 'boolean)
 
 (defcustom package-build-stable nil
-  "When non-nil, `package-build' tries to build packages from versions-tagged code."
+  "When non-nil, then try to build packages from versions-tagged code."
   :group 'package-build
   :type 'boolean)
 
@@ -113,7 +113,8 @@ Certain package names (e.g. \"@\") may not work properly with a BSD tar."
   :type '(file :must-match t))
 
 (defcustom package-build-write-melpa-badge-images nil
-  "When non-nil, write MELPA badge images alongside packages, for use on GitHub pages etc."
+  "When non-nil, write MELPA badge images alongside packages.
+These batches can, for example, be used on GitHub pages."
   :group 'package-build
   :type 'boolean)
 
@@ -188,14 +189,16 @@ or nil if the version cannot be parsed."
             (format "%d" (string-to-number (format-time-string "%H%M" time))))))
 
 (defun package-build--find-parse-time (regex &optional bound)
-  "Find REGEX in current buffer and format as a time-based version string, \
-optionally looking only as far back as BOUND."
+  "Find REGEX in current buffer and format as a time-based version string.
+An optional second argument bounds the search; it is a buffer
+position.  The match found must not end after that position."
   (package-build--parse-time (and (re-search-backward regex bound t)
                                   (match-string-no-properties 1))))
 
 (defun package-build--find-parse-time-newest (regex &optional bound)
-  "Find REGEX in current buffer and format as a time-based version string, \
-optionally looking only as far back as BOUND."
+  "Find REGEX in current buffer and format as a time-based version string.
+An optional second argument bounds the search; it is a buffer
+position.  The match found must not end after that position."
   (save-match-data
     (let (cur matches)
       (while (setq cur (ignore-errors
@@ -204,7 +207,9 @@ optionally looking only as far back as BOUND."
       (car (nreverse (sort matches 'string<))))))
 
 (defun package-build--find-version-newest (regex &optional bound)
-  "Find the newest version matching REGEX before point, optionally stopping at BOUND."
+  "Find the newest version matching REGEX before point.
+An optional second argument bounds the search; it is a buffer
+position.  The match found must not before after that position."
   (let ((tags (split-string
                (buffer-substring-no-properties
                 (or bound (point-min)) (point))
@@ -261,7 +266,8 @@ Output is written to the current buffer."
                  argv exit-code (buffer-string))))))
 
 (defun package-build--run-process-match (regex dir prog &rest args)
-  "Find match for REGEX when - in DIR, or `default-directory' if unset - we run PROG with ARGS."
+  "Run PROG with args and return the first match for REGEX in its output.
+PROG is run in DIR, or if that is nil in `default-directory'."
   (with-temp-buffer
     (apply 'package-build--run-process dir prog args)
     (goto-char (point-min))

--- a/package-build.el
+++ b/package-build.el
@@ -1318,7 +1318,6 @@ Returns the archive entry for the package."
                                   " "))
       (package-build--url-copy-file badge-url badge-filename t))))
 
-
 ;;; Helpers for recipe authors
 
 (defvar package-build-minor-mode-map
@@ -1405,7 +1404,6 @@ Returns the archive entry for the package."
        (package-build--message "%s" (error-message-string err))
        nil))))
 
-
 ;;;###autoload
 (defun package-build-all ()
   "Build all packages in the `package-build-recipe-alist'."
@@ -1474,7 +1472,6 @@ If FILE-NAME is not specified, the default archive-contents file is used."
           (setq entries (remove old entries)))
         (add-to-list 'entries new)))))
 
-
 ;;; Exporting data as json
 
 (defun package-build-recipe-alist-as-json (file-name)


### PR DESCRIPTION
I actually wrote most of this around the time when `package-build.el` got its own repository, but did not get around to finishing it.

You might want to drop the last commit as it adds a dependency on Emacs 24.5.

The two commits before that are the most important to me. See in particular the commit message of 3b8834e4521653add4842ffadd93126058ce0742. I did that because I was looking into melpa/melpa#2955 and found it hard to determine what parts of the code were relevant to that.

The remaining commits implement assorted cleanup, which also helped me understand the existing code.