### PR TITLE
Use consistent name and type for the "the package" argument

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -721,8 +721,8 @@ to build the recipe."
 
 (defun package-build--read-recipes ()
   "Return a list of data structures for all recipes."
-  (cl-loop for file-name in (directory-files package-build-recipes-dir t "^[^.]")
-           collect (package-build--read-recipe file-name)))
+  (mapcar #'package-build--read-recipe
+          (directory-files package-build-recipes-dir t "^[^.]")))
 
 (defun package-build--read-recipes-ignore-errors ()
   "Return a list of data structures for all recipes."

--- a/package-build.el
+++ b/package-build.el
@@ -677,47 +677,47 @@ of the same-named package which is to be kept."
 ;;; Recipes
 
 (defun package-build--read-recipe (file-name)
-  "Return the plist of recipe info for the package called FILE-NAME.
+  "Return the recipe of the package named FILE-NAME as a list.
 It performs some basic checks on the recipe to ensure that known
 keys have values of the right types, and raises an error if that
 is the not the case.  If invalid combinations of keys are
 supplied then errors will only be caught when an attempt is made
 to build the recipe."
-  (let* ((pkg-info (package-build--read-from-file file-name))
-         (pkg-name (car pkg-info))
-         (rest (cdr pkg-info)))
-    (cl-assert pkg-name)
-    (cl-assert (symbolp pkg-name))
-    (cl-assert (string= (symbol-name pkg-name) (file-name-nondirectory file-name))
+  (let* ((recipe (package-build--read-from-file file-name))
+         (ident (car recipe))
+         (plist (cdr recipe)))
+    (cl-assert ident)
+    (cl-assert (symbolp ident))
+    (cl-assert (string= (symbol-name ident) (file-name-nondirectory file-name))
                nil
                "Recipe '%s' contains mismatched package name '%s'"
                (file-name-nondirectory file-name)
-               pkg-name)
-    (cl-assert rest)
+               ident)
+    (cl-assert plist)
     (let* ((symbol-keys '(:fetcher))
            (string-keys '(:url :repo :module :commit :branch :version-regexp))
            (list-keys '(:files :old-names))
            (all-keys (append symbol-keys string-keys list-keys)))
-      (dolist (thing rest)
+      (dolist (thing plist)
         (when (keywordp thing)
           (cl-assert (memq thing all-keys) nil "Unknown keyword %S" thing)))
-      (let ((fetcher (plist-get rest :fetcher)))
+      (let ((fetcher (plist-get plist :fetcher)))
         (cl-assert fetcher nil ":fetcher is missing")
         (when (memq fetcher '(github gitlab bitbucket))
-          (cl-assert (plist-get rest :repo) ":repo is missing")))
+          (cl-assert (plist-get plist :repo) ":repo is missing")))
       (dolist (key symbol-keys)
-        (let ((val (plist-get rest key)))
+        (let ((val (plist-get plist key)))
           (when val
             (cl-assert (symbolp val) nil "%s must be a symbol but is %S" key val))))
       (dolist (key list-keys)
-        (let ((val (plist-get rest key)))
+        (let ((val (plist-get plist key)))
           (when val
             (cl-assert (listp val) nil "%s must be a list but is %S" key val))))
       (dolist (key string-keys)
-        (let ((val (plist-get rest key)))
+        (let ((val (plist-get plist key)))
           (when val
             (cl-assert (stringp val) nil "%s must be a string but is %S" key val)))))
-    pkg-info))
+    recipe))
 
 (defun package-build--read-recipes ()
   "Return a list of data structures for all recipes."

--- a/package-build.el
+++ b/package-build.el
@@ -876,7 +876,7 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
   (car (rassoc target files)))
 
 (defun package-build--find-package-file (name)
-  "Return the filename of the most recently built package of NAME."
+  "Return the most recently built archive of the package named NAME."
   (package-build--archive-file-name (assoc name (package-build-archive-alist))))
 
 (defun package-build--package-buffer-info-vec ()
@@ -917,7 +917,7 @@ and a cl struct in Emacs HEAD.  This wrapper normalises the results."
 ;; older date than the version timestamp provided here, the function
 ;; will return t.
 (defun package-build--up-to-date-p (name version)
-  "Return non-nil if there is an up-to-date package for NAME with the given VERSION."
+  "Return non-nil if there is an up-to-date package named NAME with the given VERSION."
   (let* ((package-file-base (expand-file-name (format "%s-%s." name version)
                                               package-build-archive-dir))
          (recipe-file (expand-file-name name package-build-recipes-dir)))
@@ -953,7 +953,7 @@ ARCHIVE-ENTRY is destructively modified."
 
 ;;;###autoload
 (defun package-build-archive (name)
-  "Build a package archive for package NAME."
+  "Build a package archive for the package named NAME."
   (interactive (list (package-build--package-name-completing-read)))
   (let* ((file-name (symbol-name name))
          (rcp (or (cdr (assoc name (package-build-recipe-alist)))
@@ -995,7 +995,7 @@ ARCHIVE-ENTRY is destructively modified."
       (list file-name version))))
 
 (defun package-build-archive-ignore-errors (pkg)
-  "Build archive for package PKG, ignoring any errors."
+  "Build archive for the package named PKG, ignoring any errors."
   (interactive (list (package-build--package-name-completing-read)))
   (let* ((debug-on-error t)
          (debug-on-signal t)
@@ -1011,7 +1011,7 @@ ARCHIVE-ENTRY is destructively modified."
 
 ;;;###autoload
 (defun package-build-package (package-name version file-specs source-dir target-dir)
-  "Create PACKAGE-NAME with VERSION.
+  "Create version VERSION of the package named PACKAGE-NAME.
 
 The information in FILE-SPECS is used to gather files from
 SOURCE-DIR.
@@ -1215,7 +1215,7 @@ If FILE-NAME is not specified, the default archive-contents file is used."
 
 ;;;###autoload
 (defun package-build-create-recipe (name fetcher)
-  "Create a new recipe for package NAME using FETCHER."
+  "Create a new recipe for the package named NAME using FETCHER."
   (interactive
    (list (intern (read-string "Package name: "))
          (intern (completing-read "Fetcher: "

--- a/package-build.el
+++ b/package-build.el
@@ -726,16 +726,13 @@ to build the recipe."
 
 (defun package-build--read-recipes-ignore-errors ()
   "Return a list of data structures for all recipes."
-  (cl-loop for file-name in (directory-files package-build-recipes-dir t "^[^.]")
-           for pkg-info = (condition-case err
-                              (package-build--read-recipe file-name)
-                            (error (package-build--message
-                                    "Error reading recipe %s: %s"
-                                    file-name
-                                    (error-message-string err))
-                                   nil))
-           when pkg-info
-           collect pkg-info))
+  (cl-mapcan (lambda (file)
+               (condition-case err
+                   (list (package-build--read-recipe file))
+                 (error (package-build--message "Error reading recipe %s: %s"
+                                                file (error-message-string err))
+                        nil)))
+             (directory-files package-build-recipes-dir t "^[^.]")))
 
 (defun package-build-expand-file-specs (dir specs &optional subdir allow-empty)
   "In DIR, expand SPECS, optionally under SUBDIR.


### PR DESCRIPTION
Implements #10.

This still needs testing, but you might want to take a look already anyway.