### PR TITLE
Massive refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+-include config.mk
+
+PKG = package-build
+
+ELS   = $(PKG).el
+ELS  += package-build-badges.el
+ELS  += package-recipe-mode.el
+ELCS  = $(ELS:.el=.elc)
+
+DEPS  =
+
+EMACS      ?= emacs
+EMACS_ARGS ?=
+
+LOAD_PATH  ?= $(addprefix -L ../,$(DEPS))
+LOAD_PATH  += -L .
+
+all: lisp
+
+help:
+	$(info make [all|lisp]   - generate byte-code and autoloads)
+	$(info make clean        - remove generated files)
+	@printf "\n"
+
+lisp: $(ELCS) loaddefs
+
+loaddefs: $(PKG)-autoloads.el
+
+%.elc: %.el
+	@printf "Compiling $<\n"
+	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) -f batch-byte-compile $<
+
+CLEAN  = $(ELCS) $(PKG)-autoloads.el
+
+clean:
+	@printf "Cleaning...\n"
+	@rm -rf $(CLEAN)
+
+define LOADDEFS_TMPL
+;;; $(PKG)-autoloads.el --- automatically extracted autoloads
+;;
+;;; Code:
+(add-to-list 'load-path (directory-file-name \
+(or (file-name-directory #$$) (car load-path))))
+
+;; Local Variables:
+;; version-control: never
+;; no-byte-compile: t
+;; no-update-autoloads: t
+;; End:
+;;; $(PKG)-autoloads.el ends here
+endef
+export LOADDEFS_TMPL
+#'
+
+$(PKG)-autoloads.el: $(ELS)
+	@printf "Generating $@\n"
+	@printf "%s" "$$LOADDEFS_TMPL" > $@
+	@$(EMACS) -Q --batch --eval "(progn\
+	(setq make-backup-files nil)\
+	(setq vc-handled-backends nil)\
+	(setq default-directory (file-truename default-directory))\
+	(setq generated-autoload-file (expand-file-name \"$@\"))\
+	(setq find-file-visit-truename t)\
+	(update-directory-autoloads default-directory))"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PKG = package-build
 
 ELS   = $(PKG).el
 ELS  += package-build-badges.el
+ELS  += package-recipe.el
 ELS  += package-recipe-mode.el
 ELCS  = $(ELS:.el=.elc)
 

--- a/package-build.el
+++ b/package-build.el
@@ -282,17 +282,17 @@ Returns the package version as a string."
 
 (defun package-build--checkout-git (name config dir)
   "Check package NAME with config CONFIG out of git into DIR."
-  (let ((repo (plist-get config :url)))
+  (let ((url (plist-get config :url)))
     (cond
      ((and (file-exists-p (expand-file-name ".git" dir))
-           (string-equal (package-build--git-repo dir) repo))
+           (string-equal (package-build--git-repo dir) url))
       (package-build--message "Updating %s" dir)
       (package-build--run-process dir nil "git" "fetch" "--all" "--tags"))
      (t
       (when (file-exists-p dir)
         (delete-directory dir t))
-      (package-build--message "Cloning %s to %s" repo dir)
-      (package-build--run-process nil nil "git" "clone" repo dir)))
+      (package-build--message "Cloning %s to %s" url dir)
+      (package-build--run-process nil nil "git" "clone" url dir)))
     (if package-build-stable
         (cl-destructuring-bind (tag . version)
             (or (package-build--find-version-newest
@@ -352,18 +352,18 @@ Returns the package version as a string."
 
 (defun package-build--checkout-hg (name config dir)
   "Check package NAME with config CONFIG out of hg into DIR."
-  (let ((repo (plist-get config :url)))
+  (let ((url (plist-get config :url)))
     (cond
      ((and (file-exists-p (expand-file-name ".hg" dir))
-           (string-equal (package-build--hg-repo dir) repo))
+           (string-equal (package-build--hg-repo dir) url))
       (package-build--message "Updating %s" dir)
       (package-build--run-process dir nil "hg" "pull")
       (package-build--run-process dir nil "hg" "update"))
      (t
       (when (file-exists-p dir)
         (delete-directory dir t))
-      (package-build--message "Cloning %s to %s" repo dir)
-      (package-build--run-process nil nil "hg" "clone" repo dir)))
+      (package-build--message "Cloning %s to %s" url dir)
+      (package-build--run-process nil nil "hg" "clone" url dir)))
     (if package-build-stable
         (cl-destructuring-bind (tag . version)
             (or (package-build--find-version-newest

--- a/package-build.el
+++ b/package-build.el
@@ -793,10 +793,6 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
   "Read the name of a package and return it as a string."
   (completing-read "Package: " (package-build-packages)))
 
-(defun package-build--find-source-file (target files)
-  "Search for source of TARGET in FILES."
-  (car (rassoc target files)))
-
 (defun package-build--find-package-file (name)
   "Return the most recently built archive of the package named NAME."
   (package-build--archive-file-name
@@ -969,10 +965,10 @@ in `package-build-archive-dir'."
         (let* ((pkg-dir-name (concat name "-" version))
                (pkg-tmp-dir (expand-file-name pkg-dir-name tmp-dir))
                (pkg-file (concat name "-pkg.el"))
-               (pkg-file-source (or (package-build--find-source-file pkg-file files)
+               (pkg-file-source (or (car (rassoc pkg-file files))
                                     pkg-file))
                (file-source (concat name ".el"))
-               (pkg-source (or (package-build--find-source-file file-source files)
+               (pkg-source (or (car (rassoc file-source files))
                                file-source))
                (pkg-info (package-build--merge-package-info
                           (let ((default-directory source-dir))

--- a/package-build.el
+++ b/package-build.el
@@ -361,7 +361,6 @@ is used instead."
   "Write DATA to FILE as a Lisp sexp.
 Optionally PRETTY-PRINT the data."
   (with-temp-file file
-    (package-build--message "File: %s" file)
     (if pretty-print
         (pp data (current-buffer))
       (print data (current-buffer)))))

--- a/package-build.el
+++ b/package-build.el
@@ -275,17 +275,12 @@ Returns the package version as a string."
 
 ;;;; Git
 
-(defun package-build--git-repo (dir)
-  "Get the current git repo for DIR."
-  (let ((default-directory dir))
-    (car (process-lines "git" "config" "remote.origin.url"))))
-
 (defun package-build--checkout-git (name config dir)
   "Check package NAME with config CONFIG out of git into DIR."
   (let ((url (plist-get config :url)))
     (cond
      ((and (file-exists-p (expand-file-name ".git" dir))
-           (string-equal (package-build--git-repo dir) url))
+           (string-equal (package-build--used-git-url dir) url))
       (package-build--message "Updating %s" dir)
       (package-build--run-process dir nil "git" "fetch" "--all" "--tags"))
      (t
@@ -312,6 +307,11 @@ Returns the package version as a string."
                    (package-build--expand-source-file-list dir config))) "\
 \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
 [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)"))))
+
+(defun package-build--used-git-url (dir)
+  "Get the current git repo for DIR."
+  (let ((default-directory dir))
+    (car (process-lines "git" "config" "remote.origin.url"))))
 
 (defun package-build--git-head-branch (dir)
   "Get the current git repo for DIR."
@@ -346,16 +346,12 @@ Returns the package version as a string."
 
 ;;;; Hg
 
-(defun package-build--hg-repo (dir)
-  "Get the current hg repo for DIR."
-  (package-build--run-process-match "default = \\(.*\\)" dir "hg" "paths"))
-
 (defun package-build--checkout-hg (name config dir)
   "Check package NAME with config CONFIG out of hg into DIR."
   (let ((url (plist-get config :url)))
     (cond
      ((and (file-exists-p (expand-file-name ".hg" dir))
-           (string-equal (package-build--hg-repo dir) url))
+           (string-equal (package-build--used-hg-url dir) url))
       (package-build--message "Updating %s" dir)
       (package-build--run-process dir nil "hg" "pull")
       (package-build--run-process dir nil "hg" "update"))
@@ -382,6 +378,12 @@ Returns the package version as a string."
                    (package-build--expand-source-file-list dir config))) "\
 \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
 [0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)"))))
+
+(defun package-build--used-hg-url (dir)
+  "Get the current hg repo for DIR."
+  (package-build--run-process-match "default = \\(.*\\)"
+                                    dir
+                                    "hg" "paths"))
 
 (defun package-build--checkout-bitbucket (name config dir)
   "Check package NAME with config CONFIG out of bitbucket into DIR."

--- a/package-build.el
+++ b/package-build.el
@@ -779,6 +779,8 @@ for ALLOW-EMPTY to prevent this error."
           (package-build-expand-file-specs
            dir (package-build--config-file-list config))))
 
+;;; Info Manuals
+
 (defun package-build--generate-info-files (files source-dir target-dir)
   "Create .info files from any .texi files listed in FILES.
 
@@ -808,8 +810,6 @@ deleted."
         (package-build--message "Removing %s"
                                 (expand-file-name dest-file target-dir))
         (delete-file (expand-file-name dest-file target-dir))))))
-
-;;; Info Manuals
 
 (defun package-build--generate-dir-file (files target-dir)
   "Create dir file from any .info files listed in FILES in TARGET-DIR."

--- a/package-build.el
+++ b/package-build.el
@@ -904,24 +904,23 @@ ARCHIVE-ENTRY is destructively modified."
 (defun package-build-archive (name)
   "Build a package archive for the package named NAME."
   (interactive (list (package-build--package-name-completing-read)))
-  (let ((rcp (or (cdr (assoc (intern name)
-                             (package-build-recipe-alist)))
+  (let ((rcp (or (cdr (assq (intern name)
+                            (package-build-recipe-alist)))
                  (error "Cannot find package %s" name))))
     (unless (file-exists-p package-build-archive-dir)
       (package-build--message "Creating directory %s" package-build-archive-dir)
       (make-directory package-build-archive-dir))
-
     (package-build--message "\n;;; %s\n" name)
-    (let* ((version (package-build-checkout name rcp))
-           (commit (package-build-get-commit name rcp))
-           (default-directory package-build-working-dir)
-           (start-time (current-time)))
+    (let ((default-directory package-build-working-dir)
+          (version (package-build-checkout name rcp))
+          (start-time (current-time)))
       (if (package-build--up-to-date-p name version)
           (package-build--message "Package %s is up to date - skipping." name)
         (progn
           (let ((archive-entry (package-build-package
                                 name version
-                                (package-build--config-file-list rcp))))
+                                (package-build--config-file-list rcp)))
+                (commit (package-build-get-commit name rcp)))
             (when commit
               (package-build-add-to-archive archive-entry :commit commit))
             (package-build--dump archive-entry

--- a/package-build.el
+++ b/package-build.el
@@ -231,8 +231,7 @@ position.  The match found must not before after that position."
              (version (package-build--valid-version tag regexp)))
         (when (and version (version-list-<= (cdr ret) version))
           (setq ret (cons tag version)))))
-    (and (car ret)
-         (list (cdr ret) (car ret)))))
+    (and (car ret) ret)))
 
 ;;; Run Process
 
@@ -317,9 +316,9 @@ Returns the package version as a string."
                             min-bound)
                            (error "No valid stable versions found for %s" name)))))
             (package-build--update-git-to-ref
-             dir (concat "tags/" (cadr tag-version)))
+             dir (concat "tags/" (car tag-version)))
             ;; Return the parsed version as a string
-            (package-version-join (car tag-version)))
+            (package-version-join (cdr tag-version)))
         (package-build--update-git-to-ref
          dir (or (plist-get config :commit)
                  (concat "origin/"
@@ -409,9 +408,9 @@ Returns the package version as a string."
             (setq tag-version
                   (or (package-build--find-version-newest regexp min-bound)
                       (error "No valid stable versions found for %s" name)))
-            (package-build--run-process dir "hg" "update" (cadr tag-version))
+            (package-build--run-process dir "hg" "update" (car tag-version))
             ;; Return the parsed version as a string
-            (package-version-join (car tag-version)))
+            (package-version-join (cdr tag-version)))
         (apply 'package-build--run-process
                dir "hg" "log" "--style" "compact" "-l1"
                (package-build--expand-source-file-list dir config))

--- a/package-build.el
+++ b/package-build.el
@@ -707,8 +707,11 @@ to build the recipe."
           (cl-assert (memq thing all-keys) nil "Unknown keyword %S" thing)))
       (let ((fetcher (plist-get plist :fetcher)))
         (cl-assert fetcher nil ":fetcher is missing")
-        (when (memq fetcher '(github gitlab bitbucket))
-          (cl-assert (plist-get plist :repo) ":repo is missing")))
+        (if (memq fetcher '(github gitlab bitbucket))
+            (progn
+              (cl-assert (plist-get plist :repo) ":repo is missing")
+              (cl-assert (not (plist-get plist :url)) ":url is redundant"))
+          (cl-assert (plist-get plist :url) ":url is missing")))
       (dolist (key symbol-keys)
         (let ((val (plist-get plist key)))
           (when val

--- a/package-build.el
+++ b/package-build.el
@@ -261,6 +261,7 @@ is used instead."
 ;;;; Common
 
 (cl-defmethod package-build--checkout :before ((rcp package-recipe))
+  (package-build--message "Package: %s" (oref rcp name))
   (package-build--message "Fetcher: %s"
                           (substring (symbol-name (eieio-object-class rcp))
                                      8 -7))
@@ -867,7 +868,6 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
     (unless (file-exists-p package-build-archive-dir)
       (package-build--message "Creating directory %s" package-build-archive-dir)
       (make-directory package-build-archive-dir))
-    (package-build--message "\n;;; %s\n" name)
     (let ((default-directory package-build-working-dir)
           (version (package-build--checkout rcp)))
       (if (package-build--up-to-date-p name version)

--- a/package-build.el
+++ b/package-build.el
@@ -807,7 +807,7 @@ deleted."
            (concat "--dir=" (expand-file-name "dir" target-dir))
            info-path))))))
 
-;;; Utilities
+;;; Building Utilities
 
 (defun package-build--copy-package-files (files source-dir target-dir)
   "Copy FILES from SOURCE-DIR to TARGET-DIR.

--- a/package-build.el
+++ b/package-build.el
@@ -653,20 +653,16 @@ If PKG-INFO is nil, an empty one is created."
      (format "%s-%s.entry" name version)
      package-build-archive-dir)))
 
-(defun package-build--delete-file-if-exists (file)
-  "Delete FILE if it exists."
-  (when (file-exists-p file)
-    (delete-file file)))
-
 (defun package-build--remove-archive-files (archive-entry)
   "Remove ARCHIVE-ENTRY from archive-contents, and delete associated file.
 Note that the working directory (if present) is not deleted by
 this function, since the archive list may contain another version
 of the same-named package which is to be kept."
   (package-build--message "Removing archive: %s" archive-entry)
-  (mapcar 'package-build--delete-file-if-exists
-          (list  (package-build--archive-file-name archive-entry)
-                 (package-build--entry-file-name archive-entry))))
+  (dolist (file (list (package-build--archive-file-name archive-entry)
+                      (package-build--entry-file-name archive-entry)))
+    (when (file-exists-p file)
+      (delete-file file))))
 
 ;;; Recipes
 

--- a/package-build.el
+++ b/package-build.el
@@ -668,7 +668,22 @@ of the same-named package which is to be kept."
           (list  (package-build--archive-file-name archive-entry)
                  (package-build--entry-file-name archive-entry))))
 
-;;; Recipes (1/2)
+;;; Recipes
+
+(defun package-build-recipe-alist ()
+  "Return the list of available package recipes."
+  (or package-build--recipe-alist
+      (setq package-build--recipe-alist
+            (package-build--read-recipes-ignore-errors))))
+
+(defun package-build-packages ()
+  "Return the list of the names of available packages."
+  (mapcar #'car (package-build-recipe-alist)))
+
+(defun package-build-reinitialize ()
+  "Forget any information about packages which have already been built."
+  (interactive)
+  (setq package-build--recipe-alist nil))
 
 (defun package-build--read-recipe (name)
   "Return the recipe of the package named NAME as a list.
@@ -1137,23 +1152,6 @@ Returns the archive entry for the package."
                                   collect built)))
     (mapc 'package-build--remove-archive-files stale-archives)
     (package-build-dump-archive-contents)))
-
-;;; Recipes (2/2)
-
-(defun package-build-recipe-alist ()
-  "Return the list of available package recipes."
-  (or package-build--recipe-alist
-      (setq package-build--recipe-alist
-            (package-build--read-recipes-ignore-errors))))
-
-(defun package-build-packages ()
-  "Return the list of the names of available packages."
-  (mapcar #'car (package-build-recipe-alist)))
-
-(defun package-build-reinitialize ()
-  "Forget any information about packages which have already been built."
-  (interactive)
-  (setq package-build--recipe-alist nil))
 
 ;;; Archive
 

--- a/package-build.el
+++ b/package-build.el
@@ -571,6 +571,15 @@ If PKG-INFO is nil, an empty one is created."
   (let ((entry (package-build--archive-entry rcp pkg-info type)))
     (package-build--dump entry (package-build--entry-file-name entry))))
 
+(cl-defmethod package-build-get-commit ((rcp package-git-recipe))
+  (ignore-errors
+    (package-build--run-process-match
+     "\\(.*\\)"
+     (package-recipe--working-tree rcp)
+     "git" "rev-parse" "HEAD")))
+
+(cl-defmethod package-build-get-commit ((rcp package-hg-recipe))) ; TODO
+
 (defun package-build--archive-entry (rcp pkg-info type)
   (let ((name (intern (aref pkg-info 0)))
         (requires (aref pkg-info 1))
@@ -847,15 +856,6 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
                        (file-newer-than-file-p package-file
                                                package-build--this-file)))
           (cl-return t))))))
-
-(cl-defmethod package-build-get-commit ((rcp package-git-recipe))
-  (ignore-errors
-    (package-build--run-process-match
-     "\\(.*\\)"
-     (package-recipe--working-tree rcp)
-     "git" "rev-parse" "HEAD")))
-
-(cl-defmethod package-build-get-commit ((rcp package-hg-recipe))) ; TODO
 
 ;;; Building
 

--- a/package-build.el
+++ b/package-build.el
@@ -852,23 +852,16 @@ deleted."
 (defun package-build--copy-package-files (files source-dir target-dir)
   "Copy FILES from SOURCE-DIR to TARGET-DIR.
 FILES is a list of (SOURCE . DEST) relative filepath pairs."
-  (cl-loop for (source-file . dest-file) in files
-           do (package-build--copy-file
-               (expand-file-name source-file source-dir)
-               (expand-file-name dest-file target-dir))))
-
-(defun package-build--copy-file (file newname)
-  "Copy FILE to NEWNAME and create parent directories for NEWNAME if they don't exist."
-  (let ((newdir (file-name-directory newname)))
-    (unless (file-exists-p newdir)
-      (make-directory newdir t)))
-  (cond
-   ((file-regular-p file)
-    (package-build--message "%s -> %s" file newname)
-    (copy-file file newname))
-   ((file-directory-p file)
-    (package-build--message "%s => %s" file newname)
-    (copy-directory file newname))))
+  (pcase-dolist (`(,src . ,dst) files)
+    (setq src (expand-file-name src source-dir))
+    (setq dst (expand-file-name dst target-dir))
+    (make-directory (file-name-directory dst) t)
+    (cond ((file-regular-p src)
+           (package-build--message "%s -> %s" src dst)
+           (copy-file src dst))
+          ((file-directory-p src)
+           (package-build--message "%s => %s" src dst)
+           (copy-directory src dst)))))
 
 (defun package-build--package-name-completing-read ()
   "Read the name of a package and return it as a string."

--- a/package-build.el
+++ b/package-build.el
@@ -260,6 +260,11 @@ PROG is run in DIR, or if that is nil in `default-directory'."
     (re-search-forward regexp)
     (match-string-no-properties 1)))
 
+(defun package-build--process-lines (directory command &rest args)
+  (with-temp-buffer
+    (apply 'package-build--run-process directory command args)
+    (split-string (buffer-string) "\n" t)))
+
 ;;; Checkout
 ;;;; Common
 

--- a/package-build.el
+++ b/package-build.el
@@ -571,14 +571,14 @@ If PKG-INFO is nil, an empty one is created."
   (let ((entry (package-build--archive-entry rcp pkg-info type)))
     (package-build--dump entry (package-build--entry-file-name entry))))
 
-(cl-defmethod package-build-get-commit ((rcp package-git-recipe))
+(cl-defmethod package-build--get-commit ((rcp package-git-recipe))
   (ignore-errors
     (package-build--run-process-match
      "\\(.*\\)"
      (package-recipe--working-tree rcp)
      "git" "rev-parse" "HEAD")))
 
-(cl-defmethod package-build-get-commit ((rcp package-hg-recipe))) ; TODO
+(cl-defmethod package-build--get-commit ((rcp package-hg-recipe))) ; TODO
 
 (defun package-build--archive-entry (rcp pkg-info type)
   (let ((name (intern (aref pkg-info 0)))
@@ -587,7 +587,7 @@ If PKG-INFO is nil, an empty one is created."
         (version (aref pkg-info 3))
         (extras (and (> (length pkg-info) 4)
                      (aref pkg-info 4)))
-        (commit (package-build-get-commit rcp)))
+        (commit (package-build--get-commit rcp)))
     (when commit
       (push (cons :commit commit) extras))
     (cons name

--- a/package-build.el
+++ b/package-build.el
@@ -904,7 +904,8 @@ ARCHIVE-ENTRY is destructively modified."
 (defun package-build-archive (name)
   "Build a package archive for the package named NAME."
   (interactive (list (package-build--package-name-completing-read)))
-  (let ((rcp (or (cdr (assq (intern name)
+  (let ((start-time (current-time))
+        (rcp (or (cdr (assq (intern name)
                             (package-build-recipe-alist)))
                  (error "Cannot find package %s" name))))
     (unless (file-exists-p package-build-archive-dir)
@@ -912,8 +913,7 @@ ARCHIVE-ENTRY is destructively modified."
       (make-directory package-build-archive-dir))
     (package-build--message "\n;;; %s\n" name)
     (let ((default-directory package-build-working-dir)
-          (version (package-build-checkout name rcp))
-          (start-time (current-time)))
+          (version (package-build-checkout name rcp)))
       (if (package-build--up-to-date-p name version)
           (package-build--message "Package %s is up to date - skipping." name)
         (progn

--- a/package-build.el
+++ b/package-build.el
@@ -852,16 +852,21 @@ deleted."
 (defun package-build--copy-package-files (files source-dir target-dir)
   "Copy FILES from SOURCE-DIR to TARGET-DIR.
 FILES is a list of (SOURCE . DEST) relative filepath pairs."
+  (package-build--message
+   "Copying files (->) and directories (=>)\n  from %s\n  to %s"
+   source-dir target-dir)
   (pcase-dolist (`(,src . ,dst) files)
-    (setq src (expand-file-name src source-dir))
-    (setq dst (expand-file-name dst target-dir))
-    (make-directory (file-name-directory dst) t)
-    (cond ((file-regular-p src)
-           (package-build--message "%s -> %s" src dst)
-           (copy-file src dst))
-          ((file-directory-p src)
-           (package-build--message "%s => %s" src dst)
-           (copy-directory src dst)))))
+    (let ((src* (expand-file-name src source-dir))
+          (dst* (expand-file-name dst target-dir)))
+      (make-directory (file-name-directory dst*) t)
+      (cond ((file-regular-p src*)
+             (package-build--message
+              "  %s %s -> %s" (if (equal src dst) " " "!") src dst)
+             (copy-file src* dst*))
+            ((file-directory-p src*)
+             (package-build--message
+              "  %s %s => %s" (if (equal src dst) " " "!") src dst)
+             (copy-directory src* dst*))))))
 
 (defun package-build--package-name-completing-read ()
   "Read the name of a package and return it as a string."

--- a/package-build.el
+++ b/package-build.el
@@ -699,7 +699,7 @@ to build the recipe."
                name ident)
     (cl-assert plist)
     (let* ((symbol-keys '(:fetcher))
-           (string-keys '(:url :repo :module :commit :branch :version-regexp))
+           (string-keys '(:url :repo :commit :branch :version-regexp))
            (list-keys '(:files :old-names))
            (all-keys (append symbol-keys string-keys list-keys)))
       (dolist (thing plist)

--- a/package-build.el
+++ b/package-build.el
@@ -1093,7 +1093,7 @@ Returns the archive entry for the package."
                (pkg-info (package-build--merge-package-info
                           (let ((default-directory source-dir))
                             (or (package-build--get-pkg-file-info pkg-file-source)
-                                ;; some packages (like magit) provide name-pkg.el.in
+                                ;; Some packages provide NAME-pkg.el.in
                                 (package-build--get-pkg-file-info
                                  (expand-file-name (concat pkg-file ".in")
                                                    (file-name-directory pkg-source)))

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -1,0 +1,108 @@
+;;; package-recipe.el --- Package recipes as EIEIO objects  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2018  Jonas Bernoulli
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+
+;; This file is not (yet) part of GNU Emacs.
+;; However, it is distributed under the same license.
+
+;; GNU Emacs is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; Package recipes as EIEIO objects.
+
+;;; Code:
+
+(require 'eieio)
+
+(declare-function package-build-recipe-alist "package-build" ())
+(defvar package-build-working-dir)
+
+;;; Classes
+
+(defclass package-recipe ()
+  ((url-format      :allocation :class       :initform nil)
+   (repopage-format :allocation :class       :initform nil)
+   (tag-regexp      :allocation :class       :initform nil)
+   (stable-p        :allocation :class       :initform nil)
+   (name            :initarg :name           :initform nil)
+   (url             :initarg :url            :initform nil)
+   (repo            :initarg :repo           :initform nil)
+   (repopage        :initarg :repopage       :initform nil)
+   (files           :initarg :files          :initform nil)
+   (branch          :initarg :branch         :initform nil)
+   (commit          :initarg :commit         :initform nil)
+   (version-regexp  :initarg :version-regexp :initform nil)
+   (old-names       :initarg :old-names      :initform nil))
+  :abstract t)
+
+(defun package-recipe-lookup (name)
+  (let ((plist (cdr (assq (intern name) (package-build-recipe-alist)))))
+    (if plist
+        (let (key val args (fetcher (plist-get plist :fetcher)))
+          (while (and (setq key (pop plist))
+                      (setq val (pop plist)))
+            (unless (eq key :fetcher)
+              (push val args)
+              (push key args)))
+          (apply (intern (format "package-%s-recipe" fetcher))
+                 :name name args))
+      (error "Cannot find valid recipe for package %s" name))))
+
+(cl-defmethod package-recipe--working-tree ((rcp package-recipe))
+  (file-name-as-directory
+   (expand-file-name (oref rcp name) package-build-working-dir)))
+
+(cl-defmethod package-recipe--upstream-url ((rcp package-recipe))
+  (or (oref rcp url)
+      (format (oref rcp url-format)
+              (oref rcp repo))))
+
+;;;; Git
+
+(defclass package-git-recipe (package-recipe)
+  ((tag-regexp      :initform "\
+\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
+[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))
+
+(defclass package-github-recipe (package-git-recipe)
+  ((url-format      :initform "https://github.com/%s.git")
+   (repopage-format :initform "https://github.com/%s")))
+
+(defclass package-gitlab-recipe (package-git-recipe)
+  ((url-format      :initform "https://gitlab.com/%s.git")
+   (repopage-format :initform "https://gitlab.com/%s")))
+
+;;;; Mercurial
+
+(defclass package-hg-recipe (package-recipe)
+  ((tag-regexp      :initform "\
+\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
+[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))
+
+(defclass package-bitbucket-recipe (package-hg-recipe)
+  ((url-format      :initform "https://bitbucket.org/%s")
+   (repopage-format :initform "https://bitbucket.org/%s")))
+
+(provide 'package-recipe)
+;; Local Variables:
+;; coding: utf-8
+;; checkdoc-minor-mode: 1
+;; indent-tabs-mode: nil
+;; End:
+;;; package-recipe.el ends here


### PR DESCRIPTION
> Subsequently I am criticizing the existing code quiet harshly.  I am pretty sure that @purcell and @milkypostman will understand that correctly, but others might read this as well, so I would like to emphasize that this is not intended as a criticism of the authors or their skills.  I maintain a project similar to Melpa and as part of that maintain tools similar to this one, and know how much work it is to just keep things going.  It is very tempting and often the only course of action that won't make you burn out or otherwise go insane to just keep adding features and fixing bugs without taking a step back and refactor.

### Motivation

1. A long time ago I have said that I would like to replace the timestamps that are used on Melpa (non-stable) with version strings of the form `VERSION.UPDATE-COUNT`.  Or something like that.  I think that the plan outlined in https://github.com/melpa/melpa/issues/2955 is fairly sound, but I haven't looked at it in a while.

   Many others have expressed interest in something like this but nobody has implemented anything. Anyway the point is that I think it should be fairly simple to do that.  But when I went looking for how to inject that feature into the existing code I ran into a lot of accidental complexity.

2. I am the maintain the [Emacsmirror](https://emacsmirror.net), which in many ways is similar to Melpa.  The primary output of Melpa is a collection of `package.el`-compatible packages, while the primary output of the Emacsmirror is a database containing a list of Git repositories containing Emacs packages, as well as lots of metadata about these packages.

   For most users the output of Melpa is more useful, but I am happy that there now are a few users who use my [Borg](https://github.com/emacscollective/borg) package manager and my [Epkg](https://github.com/emacscollective/epkg) manager.
  
   But my work on the Emacsmirror benefits Melpa users as well.  In the early days of the Emacsmirror I went looking for packages to add myself.  Nowadays I rely on Melpa for that purpose.  Some time after a package is added to Melpa, I also semi-automatically add it to the Emacsmirror.
  
   Because the Emacsmirror extracts more metadata about packages than Melpa does, that often leads to the discovery of issues that @purcell did not catch during his (very valuable) review.  I then contact the maintainer and ask them to fix the issues, or even do it for them.  These fixes make it into Melpa as well on the next update.
  
   Additionally, even though I don't use `package.el` myself, I am a top contributor to Melpa (right after the two head honchos).  By comparing the data found in Melpa and the Emacsmirror I not only find issues in individual packages but also to issues in Melpa recipes and that leads to a lot of commits.
  
   Anyway the Emacsmirror extracts a lot more metadata about packages than Melpa (or that `package.el` currently supports (give `epkg` a try)) and some of that could be ported to Melpa (and `package.el`).  But again the accidental complexity gets in the way.
  
   The Emacsmirror too could benefit from Melpa more if `package-build.el` were more similar to the respective tools used to maintain the Emacsmirror.

3. The reason I am doing this now is that after the next release Magit's development will move to two long-lived branches (likely `maint` and `master`). I would like Melpa Stable to continue to contain releases such as `2.12.1`, Melpa to stay on `maint` on offer versions like `2.12.1.5`, and my own Elpa archive to offer versions like `2.99.101` from `master`. For that I need `VERSION.UPDATE-COUNT` support, as well as some other things that I don't want to implement on top of the current `package-build.el` implementation.

Melpa could be improved in many ways, and many users request such changes, but when they are told by the overworked maintainers to lend a hand not much happens.  I think this is partially due to the accidental complexity that makes it hard to add something new.  The primary goal of these commits is to remove some of that complexity so that `package-build.el` and by extension Melpa can grow new features.

### Status

* I have only lightly tested these changes and I guess I should recommend that this pull-request isn't merged until we have done some more testing.

  Similar pull-requests that I created in the past tended to have some bugs.  These bugs were rather silly and "easily preventable", but that wasn't only the result of too little testing but is also to be expected when replacing accidental complexity with a cleaner implementation.  When there are many unnecessary complications, then it is easy to mistake a complication that actually is necessary for one of the unnecessary ones.

  So maybe it wouldn't be a bad idea to merge this pretty soon anyway, but on a day where we all are available to quickly fix any regressions encountered by users.

* This is only a step toward a cleaner code base.

  There are some temporary hacks.  I have removed many obsolete doc-strings without replacing them with new ones, because I only have so much motivation to improve things incrementally.  I am doing it for the code, but the documentation I don't want to update until things are done instead of over and over again.
  
  Also I have to turn my attention to other things now.  So it could be a while until the next patch series.
  
### Changes

* Make code that determines the appropriate version self-contained.
* Use fewer arguments to pass data around.
* Use Eieio objects to represent recipes instead of plists.  These objects contain more information than the old plists, which is what makes it possible to use fewer arguments to pass information around.
* Replace leaky abstractions with self-contained functions, doing one thing only, and all of it.

  This too is made easier by the use of objects that contain all the necessary information with no overhead such as having to add additional arguments to many functions just so that the work can be done where it makes most sense to do it.  Previously some work was done in the wrong place, simply because that was the only place where the required information was available.

* Organized the file into logical units by using sections.  This was a very necessary step, which I already began in earlier patch series.  It helps a lot recognizing accidental complexity and removing it. 

  This required moving some existing function definitions.  The order of the sections themselves and the order of definitions within a given section is still fairly random.
* Remove many helper functions, by inlining them.  These helper functions often existed because the functions that called them were to complicated, making it necessary to move at least some of the code elsewhere.  But after cleaning up the calling function that often wasn't necessary anymore.

  The existence of many tiny helper functions that are defined in weird places and have sub-optimal names and doc-strings, makes it very hard to fully grasp what a certain task involved.

  Having everything in one place helps a lot here.  Which isn't to say that tiny helper functions are bad per se, but at this point in the evolution of the code base, I feel they do more harm than good.  Also they often existed to cover up another issue, not to increase the separation of concerns.

This patch series does not fix all of the mentioned issues.  It fixes some instances of each of the mentioned issue categories, while leaving others untouched.
