### PR TITLE
Improve recipe interface

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -135,12 +135,6 @@ Otherwise do nothing."
   (when package-build-verbose
     (apply 'message format-string args)))
 
-(defun package-build--trim (str &optional chr)
-  "Return a copy of STR without any trailing CHR (or space if unspecified)."
-  (if (equal (elt str (1- (length str))) (or chr ? ))
-      (substring str 0 (1- (length str)))
-    str))
-
 ;;; Version Handling
 
 (defun package-build--parse-time (str &optional regexp)

--- a/package-build.el
+++ b/package-build.el
@@ -127,15 +127,6 @@ The string in the capture group should be parsed as valid by `version-to-list'."
   :group 'package-build
   :type 'string)
 
-;;; Internal Variables
-
-(defconst package-build-default-files-spec
-  '("*.el" "*.el.in" "dir"
-    "*.info" "*.texi" "*.texinfo"
-    "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-    (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"))
-  "Default value for :files attribute in recipes.")
-
 ;;; Generic Utilities
 
 (defun package-build--message (format-string &rest args)
@@ -598,6 +589,13 @@ of the same-named package which is to be kept."
       (delete-file file))))
 
 ;;; File Specs
+
+(defconst package-build-default-files-spec
+  '("*.el" "*.el.in" "dir"
+    "*.info" "*.texi" "*.texinfo"
+    "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
+    (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"))
+  "Default value for :files attribute in recipes.")
 
 (defun package-build-expand-file-specs (dir specs &optional subdir allow-empty)
   "In DIR, expand SPECS, optionally under SUBDIR.

--- a/package-build.el
+++ b/package-build.el
@@ -859,7 +859,7 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
           (version (package-build--checkout rcp)))
       (if (package-build--up-to-date-p name version)
           (package-build--message "Package %s is up to date - skipping." name)
-        (package-build-package rcp version)
+        (package-build--package rcp version)
         (when package-build-write-melpa-badge-images
           (package-build--write-melpa-badge-image
            name version package-build-archive-dir))
@@ -885,7 +885,7 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
        nil))))
 
 ;;;###autoload
-(defun package-build-package (rcp version)
+(defun package-build--package (rcp version)
   "Create version VERSION of the package specified by RCP.
 Return the archive entry for the package and store the package
 in `package-build-archive-dir'."

--- a/package-build.el
+++ b/package-build.el
@@ -847,9 +847,9 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
 ;;; Building
 
 ;;;###autoload
-(defun package-build-archive (name)
+(defun package-build-archive (name &optional dump-archive-contents)
   "Build a package archive for the package named NAME."
-  (interactive (list (package-build--package-name-completing-read)))
+  (interactive (list (package-build--package-name-completing-read) t))
   (let ((start-time (current-time))
         (rcp (package-recipe-lookup name)))
     (unless (file-exists-p package-build-archive-dir)
@@ -867,7 +867,9 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
                                 name
                                 (float-time (time-since start-time))
                                 (current-time-string)))
-      (list name version))))
+      (list name version)))
+  (when dump-archive-contents
+    (package-build-dump-archive-contents)))
 
 (defun package-build-archive-ignore-errors (name)
   "Build archive for the package named NAME, ignoring any errors."

--- a/package-build.el
+++ b/package-build.el
@@ -135,10 +135,6 @@ Otherwise do nothing."
   (when package-build-verbose
     (apply 'message format-string args)))
 
-(defun package-build--string-rtrim (str)
-  "Remove trailing whitespace from `STR'."
-  (replace-regexp-in-string "[ \t\n\r]+$" "" str))
-
 (defun package-build--trim (str &optional chr)
   "Return a copy of STR without any trailing CHR (or space if unspecified)."
   (if (equal (elt str (1- (length str))) (or chr ? ))

--- a/package-build.el
+++ b/package-build.el
@@ -415,12 +415,8 @@ is used instead."
       (delete-trailing-whitespace)
       (let ((coding-system-for-write buffer-file-coding-system))
         (write-region nil nil
-                      (package-build--readme-file-name target-dir file-name))))))
-
-(defun package-build--readme-file-name (target-dir file-name)
-  "Name of the readme file in TARGET-DIR for the package FILE-NAME."
-  (expand-file-name (concat file-name "-readme.txt")
-                    target-dir))
+                      (expand-file-name (concat file-name "-readme.txt")
+                                        target-dir))))))
 
 ;;; Entries
 

--- a/package-build.el
+++ b/package-build.el
@@ -700,11 +700,6 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
               "  %s %s => %s" (if (equal src dst) " " "!") src dst)
              (copy-directory src* dst*))))))
 
-(defun package-build--find-package-file (name)
-  "Return the most recently built archive of the package named NAME."
-  (package-build--archive-file-name
-   (assq (intern name) (package-build-archive-alist))))
-
 (defconst package-build--this-file load-file-name)
 
 ;; TODO: This function should be fairly sound, but it has a few

--- a/package-build.el
+++ b/package-build.el
@@ -519,7 +519,7 @@ If PKG-INFO is nil, an empty one is created."
 
 (defun package-build--write-archive-entry (rcp pkg-info type)
   (let ((entry (package-build--archive-entry rcp pkg-info type)))
-    (with-temp-file (package-build--entry-file-name entry)
+    (with-temp-file (package-build--archive-entry-file entry)
       (print entry (current-buffer)))))
 
 (defmethod package-build--get-commit ((rcp package-git-recipe))
@@ -558,7 +558,7 @@ If PKG-INFO is nil, an empty one is created."
      (format "%s-%s.%s" name version (if (eq flavour 'single) "el" "tar"))
      package-build-archive-dir)))
 
-(defun package-build--entry-file-name (archive-entry)
+(defun package-build--archive-entry-file (archive-entry)
   "Return the path of the file in which the package for ARCHIVE-ENTRY is stored."
   (let* ((name (car archive-entry))
          (pkg-info (cdr archive-entry))
@@ -929,7 +929,7 @@ artifacts, and return a list of the up-to-date archive entries."
           (let ((file (package-build--artifact-file old)))
             (when (file-exists-p file)
               (delete-file file)))
-          (let ((file (package-build--entry-file-name old)))
+          (let ((file (package-build--archive-entry-file old)))
             (when (file-exists-p file)
               (delete-file file)))
           (setq entries (remove old entries)))

--- a/package-build.el
+++ b/package-build.el
@@ -711,10 +711,6 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
               "  %s %s => %s" (if (equal src dst) " " "!") src dst)
              (copy-directory src* dst*))))))
 
-(defun package-build--package-name-completing-read ()
-  "Read the name of a package for which a recipe is available."
-  (completing-read "Package: " (package-recipe-recipes)))
-
 (defun package-build--find-package-file (name)
   "Return the most recently built archive of the package named NAME."
   (package-build--archive-file-name
@@ -745,7 +741,7 @@ FILES is a list of (SOURCE . DEST) relative filepath pairs."
 ;;;###autoload
 (defun package-build-archive (name &optional dump-archive-contents)
   "Build a package archive for the package named NAME."
-  (interactive (list (package-build--package-name-completing-read) t))
+  (interactive (list (package-recipe-read-name) t))
   (let ((start-time (current-time))
         (rcp (package-recipe-lookup name)))
     (unless (file-exists-p package-build-archive-dir)

--- a/package-build.el
+++ b/package-build.el
@@ -1002,7 +1002,7 @@ in `package-build-archive-dir'."
   (package-build-cleanup))
 
 (defun package-build-cleanup ()
-  "Remove previously-built packages that no longer have recipes."
+  "Remove previously built packages that no longer have recipes."
   (interactive)
   (let* ((known-package-names (package-build-packages))
          (stale-archives (cl-loop for built in (package-build--archive-entries)

--- a/package-build.el
+++ b/package-build.el
@@ -548,7 +548,7 @@ If PKG-INFO is nil, an empty one is created."
                   type
                   extras))))
 
-(defun package-build--archive-file-name (archive-entry)
+(defun package-build--artifact-file (archive-entry)
   "Return the path of the file in which the package for ARCHIVE-ENTRY is stored."
   (let* ((name (car archive-entry))
          (pkg-info (cdr archive-entry))
@@ -926,7 +926,7 @@ artifacts, and return a list of the up-to-date archive entries."
             ;; swap old and new
             (cl-rotatef old new))
           (package-build--message "Removing archive: %s" old)
-          (let ((file (package-build--archive-file-name old)))
+          (let ((file (package-build--artifact-file old)))
             (when (file-exists-p file)
               (delete-file file)))
           (let ((file (package-build--entry-file-name old)))

--- a/package-build.el
+++ b/package-build.el
@@ -129,10 +129,6 @@ The string in the capture group should be parsed as valid by `version-to-list'."
 
 ;;; Internal Variables
 
-(defvar package-build--archive-alist nil
-  "Internal list of already-built packages, in the standard package.el format.
-Use function `package-build-archive-alist' instead of this variable.")
-
 (defconst package-build-default-files-spec
   '("*.el" "*.el.in" "dir"
     "*.info" "*.texi" "*.texinfo"

--- a/package-build.el
+++ b/package-build.el
@@ -959,8 +959,7 @@ in `package-build-archive-dir'."
        name))
     (package-build--write-archive-entry rcp pkg-info 'single)))
 
-(defun package-build--build-multi-file-package
-    (rcp version files source-dir)
+(defun package-build--build-multi-file-package (rcp version files source-dir)
   (let* ((name (oref rcp name))
          (tmp-dir (file-name-as-directory (make-temp-file name t))))
     (unwind-protect

--- a/package-recipe-mode.el
+++ b/package-recipe-mode.el
@@ -86,8 +86,7 @@
   (check-parens)
   (package-build-reinitialize)
   (let ((name (file-name-nondirectory (buffer-file-name))))
-    (package-build-archive name)
-    (package-build-dump-archive-contents)
+    (package-build-archive name t)
     (let ((output-buffer-name "*package-build-result*"))
       (with-output-to-temp-buffer output-buffer-name
         (princ ";; Please check the following package descriptor.\n")

--- a/package-recipe-mode.el
+++ b/package-recipe-mode.el
@@ -84,7 +84,6 @@
         (save-buffer)
       (error "Aborting")))
   (check-parens)
-  (package-build-reinitialize)
   (let ((name (file-name-nondirectory (buffer-file-name))))
     (package-build-archive name t)
     (let ((output-buffer-name "*package-build-result*"))

--- a/package-recipe-mode.el
+++ b/package-recipe-mode.el
@@ -97,7 +97,7 @@
         (view-mode)))
     (when (yes-or-no-p "Install new package? ")
       (package-install-file
-       (package-build--archive-file-name
+       (package-build--artifact-file
         (assq (intern name) (package-build-archive-alist)))))))
 
 (provide 'package-recipe-mode)

--- a/package-recipe-mode.el
+++ b/package-recipe-mode.el
@@ -96,7 +96,9 @@
         (emacs-lisp-mode)
         (view-mode)))
     (when (yes-or-no-p "Install new package? ")
-      (package-install-file (package-build--find-package-file name)))))
+      (package-install-file
+       (package-build--archive-file-name
+        (assq (intern name) (package-build-archive-alist)))))))
 
 (provide 'package-recipe-mode)
 

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -30,7 +30,7 @@
 
 (require 'eieio)
 
-(declare-function package-build-recipe-alist "package-build" ())
+(defvar package-build-recipes-dir)
 (defvar package-build-working-dir)
 
 ;;; Classes
@@ -50,19 +50,6 @@
    (version-regexp  :initarg :version-regexp :initform nil)
    (old-names       :initarg :old-names      :initform nil))
   :abstract t)
-
-(defun package-recipe-lookup (name)
-  (let ((plist (cdr (assq (intern name) (package-build-recipe-alist)))))
-    (if plist
-        (let (key val args (fetcher (plist-get plist :fetcher)))
-          (while (and (setq key (pop plist))
-                      (setq val (pop plist)))
-            (unless (eq key :fetcher)
-              (push val args)
-              (push key args)))
-          (apply (intern (format "package-%s-recipe" fetcher))
-                 name :name name args))
-      (error "Cannot find valid recipe for package %s" name))))
 
 (defmethod package-recipe--working-tree ((rcp package-recipe))
   (file-name-as-directory
@@ -99,6 +86,74 @@
   ((url-format      :initform "https://bitbucket.org/%s")
    (repopage-format :initform "https://bitbucket.org/%s")))
 
+;;; Interface
+
+(defun package-recipe-recipes ()
+  "Return a list of the names of packages with available recipes."
+  (directory-files package-build-recipes-dir nil "^[^.]"))
+
+(defun package-recipe-lookup (name)
+  "Return a recipe object for the package named NAME.
+If no such recipe file exists or if the contents of the recipe
+file is invalid, then raise an error."
+  (let ((file (expand-file-name name package-build-recipes-dir)))
+    (if (file-exists-p file)
+        (let* ((recipe (with-temp-buffer
+                         (insert-file-contents file)
+                         (read (current-buffer))))
+               (plist (cdr recipe))
+               (fetcher (plist-get plist :fetcher))
+               key val args)
+          (package-recipe--validate recipe name)
+          (while (and (setq key (pop plist))
+                      (setq val (pop plist)))
+            (unless (eq key :fetcher)
+              (push val args)
+              (push key args)))
+          (apply (intern (format "package-%s-recipe" fetcher))
+                 name :name name args))
+      (error "No such recipe: %s" name))))
+
+;;; Validation
+
+(defun package-recipe--validate (recipe name)
+  "Perform some basic checks on the raw RECIPE for the package named NAME."
+  (pcase-let ((`(,ident . ,plist) recipe))
+    (cl-assert ident)
+    (cl-assert (symbolp ident))
+    (cl-assert (string= (symbol-name ident) name)
+               nil "Recipe '%s' contains mismatched package name '%s'"
+               name ident)
+    (cl-assert plist)
+    (let* ((symbol-keys '(:fetcher))
+           (string-keys '(:url :repo :commit :branch :version-regexp))
+           (list-keys '(:files :old-names))
+           (all-keys (append symbol-keys string-keys list-keys)))
+      (dolist (thing plist)
+        (when (keywordp thing)
+          (cl-assert (memq thing all-keys) nil "Unknown keyword %S" thing)))
+      (let ((fetcher (plist-get plist :fetcher)))
+        (cl-assert fetcher nil ":fetcher is missing")
+        (if (memq fetcher '(github gitlab bitbucket))
+            (progn
+              (cl-assert (plist-get plist :repo) ":repo is missing")
+              (cl-assert (not (plist-get plist :url)) ":url is redundant"))
+          (cl-assert (plist-get plist :url) ":url is missing")))
+      (dolist (key symbol-keys)
+        (let ((val (plist-get plist key)))
+          (when val
+            (cl-assert (symbolp val) nil "%s must be a symbol but is %S" key val))))
+      (dolist (key list-keys)
+        (let ((val (plist-get plist key)))
+          (when val
+            (cl-assert (listp val) nil "%s must be a list but is %S" key val))))
+      (dolist (key string-keys)
+        (let ((val (plist-get plist key)))
+          (when val
+            (cl-assert (stringp val) nil "%s must be a string but is %S" key val)))))
+    recipe))
+
+;;; _
 (provide 'package-recipe)
 ;; Local Variables:
 ;; coding: utf-8

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -92,6 +92,10 @@
   "Return a list of the names of packages with available recipes."
   (directory-files package-build-recipes-dir nil "^[^.]"))
 
+(defun package-recipe-read-name ()
+  "Read the name of a package for which a recipe is available."
+  (completing-read "Package: " (package-recipe-recipes)))
+
 (defun package-recipe-lookup (name)
   "Return a recipe object for the package named NAME.
 If no such recipe file exists or if the contents of the recipe


### PR DESCRIPTION
The main change is in 34164c01e8f5c13c3c0a26d0abce6b0801d46408. The rest continues my quest to have fewer functions so that it is easier for readers to find the actual api and follow the flow of things.

* What do you think about the name `package-recipe-lookup`? Maybe `package-recipe-get` or `package-recipe-get-recipe` would be better. Any better ideas?

* `package-recipe.el` still declares two options from `package-build.el`. The only way to properly fix that, which I can see, is to add a new file (e.g. `package-build-common.el` or `package-build options.el`) and use that to define all options or just the custom group and the path options. But that seems a bit much and we could still do it later if nothing better comes along.