### PR TITLE
Support Emacs 24.3

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -263,7 +263,7 @@ is used instead."
 (defmethod package-build--checkout :before ((rcp package-recipe))
   (package-build--message "Package: %s" (oref rcp name))
   (package-build--message "Fetcher: %s"
-                          (substring (symbol-name (eieio-object-class rcp))
+                          (substring (symbol-name (object-class-fast rcp))
                                      8 -7))
   (package-build--message "Source:  %s\n" (package-recipe--upstream-url rcp)))
 


### PR DESCRIPTION
`eieio-object-class` seems to have been introduced in Emacs 24.4. Use
the `object-class-fast` alias that is supported in earlier emacsen.

This should fix the build problems for emacs 24.3 in https://github.com/cask/cask/pull/423