### PR TITLE
Fix 5584

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -987,26 +987,28 @@ artifacts, and return a list of the up-to-date archive entries."
 
 (defun package-build--archive-alist-for-json ()
   "Return the archive alist in a form suitable for JSON encoding."
-  (cl-mapcan (lambda (entry)
-               (list (intern (format ":%s" (car entry)))
-                     (let* ((info (cdr entry))
-                            (extra (aref info 4))
-                            (maintainer (assq :maintainer extra))
-                            (authors (assq :authors extra)))
-                       (when maintainer
-                         (setcdr maintainer
-                                 (format "%s <%s>"
-                                         (cadr maintainer)
-                                         (cddr maintainer))))
-                       (when authors
-                         (setcdr authors
-                                 (mapcar (lambda (author)
-                                           (format "%s <%s>"
-                                                   (car author)
-                                                   (cdr author)))
-                                         (cdr authors))))
-                       (package-build--pkg-info-for-json info))))
-             (package-build-archive-alist)))
+  (cl-flet ((format-person
+             (person)
+             (let ((name (car person))
+                   (mail (cdr person)))
+               (if (and name mail)
+                   (format "%s <%s>" name mail)
+                 (or name
+                     (format "<%s>" mail))))))
+    (cl-mapcan (lambda (entry)
+                 (list (intern (format ":%s" (car entry)))
+                       (let* ((info (cdr entry))
+                              (extra (aref info 4))
+                              (maintainer (assq :maintainer extra))
+                              (authors (assq :authors extra)))
+                         (when maintainer
+                           (setcdr maintainer
+                                   (format-person (cdr maintainer))))
+                         (when authors
+                           (setcdr authors
+                                   (mapcar #'format-person (cdr authors))))
+                         (package-build--pkg-info-for-json info))))
+               (package-build-archive-alist))))
 
 (defun package-build-archive-alist-as-json (file)
   "Dump the build packages list to FILE as json."


### PR DESCRIPTION
```
package-build--archive-alist-for-json: Make data json-compatible

When using a newer Emacs, which defines `package-desc-create', then we
use some of information that is extracted by `package-buffer-info' but
that cannot turned into JSON as is.

This resulted in the melpa/melpa#5584 when
we finally updated Melpa to use such an Emacs.

The easiest and cleanest fix would be to just not use that information
and instead extract and format it ourselves.  However that would mean
that we would store information in archive-contents that do not
conform to what other packages who *do* use the functionality provided
by `package.el' itself would put there.

So we continue to use that data as-is and only modify it when
exporting to JSON.

The change to `pacakge-build--archive-entry' reverts the temporary
kludge introduced by befbd7f.
```

The second commit deals with the fact that the author name or mail may be missing.

```
 package-build--archive-alist-for-json: Deal with incomplete data

Avoid strings like "A U Thor <nil>" or " <author.example.com".
Favor "A U Thor <author.example.com" but fall back to "A U Thor"
or "author.example.com" if necessary.
```

would you prefer

```
...
or "<author.example.com>" if necessary.
```

?