### PR TITLE
Always use UTC timezone for HEAD version

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -139,7 +139,8 @@ Otherwise do nothing."
 ;;; Version Handling
 
 (defun package-build--parse-time (str &optional regexp)
-  "Parse STR as a time, and format as a YYYYMMDD.HHMM string."
+  "Parse STR as a time, and format as a YYYYMMDD.HHMM string.
+Always use Coordinated Universal Time (UTC) for output string."
   (unless str
     (error "No valid timestamp found"))
   (setq str (substring-no-properties str))
@@ -156,8 +157,8 @@ Otherwise do nothing."
                    (concat (match-string 1 str) "-" (match-string 2 str) "-"
                            (match-string 3 str) " " (match-string 4 str))
                  str))))
-    (concat (format-time-string "%Y%m%d." time)
-            (format "%d" (string-to-number (format-time-string "%H%M" time))))))
+    (concat (format-time-string "%Y%m%d." time t)
+            (format "%d" (string-to-number (format-time-string "%H%M" time t))))))
 
 (defun package-build--find-version-newest (tags &optional regexp)
   "Find the newest version in TAGS matching REGEXP.


### PR DESCRIPTION
I sometimes use this package on my machine. I personally use JST.
When I built a package, I noticed the package version of HEAD package was very different from one of MELPA.

I think it would be good to pin the timezone for version string to GMT, to make versions be more consistent across multiple machines.

Actually, I don't fully understand the impact of this PR.
(What is the timezone of the MELPA build server?  If it is already GMT, I think it will not be a big problem.)
If this PR is not acceptable for some reasons, please close.