### PR TITLE
Don't json-encode value of :files property

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -953,7 +953,11 @@ artifacts, and return a list of the up-to-date archive entries."
                 (with-temp-buffer
                   (insert-file-contents
                    (expand-file-name name package-build-recipes-dir))
-                  (list (read (current-buffer)))))))
+                  (let ((exp (read (current-buffer))))
+                    (when (plist-member (cdr exp) :files)
+                      (plist-put (cdr exp) :files
+                                 (format "%S" (plist-get (cdr exp) :files))))
+                    (list exp))))))
        (package-recipe-recipes))))))
 
 (defun package-build--pkg-info-for-json (info)

--- a/package-build.el
+++ b/package-build.el
@@ -946,15 +946,15 @@ artifacts, and return a list of the up-to-date archive entries."
   (with-temp-file file
     (insert
      (json-encode
-      (cl-mapcan (lambda (name)
-                   (condition-case nil
-                       ;; Filter out invalid recipes.
-                       (when (with-demoted-errors (package-recipe-lookup name))
-                         (with-temp-buffer
-                           (insert-file-contents
-                            (expand-file-name name package-build-recipes-dir))
-                           (list (read (current-buffer)))))))
-                 (package-recipe-recipes))))))
+      (cl-mapcan
+       (lambda (name)
+         (ignore-errors ; Silently ignore corrupted recipes.
+           (and (package-recipe-lookup name)
+                (with-temp-buffer
+                  (insert-file-contents
+                   (expand-file-name name package-build-recipes-dir))
+                  (list (read (current-buffer)))))))
+       (package-recipe-recipes))))))
 
 (defun package-build--pkg-info-for-json (info)
   "Convert INFO into a data structure which will serialize to JSON in the desired shape."


### PR DESCRIPTION
https://github.com/melpa/melpa/pull/5888 demonstrates how `json-encode` messes up the value of the `:files` property of recipes. IMO we should not do what's proposed in that pr and just refrain from trying to turn the value `:files` into json, by storing the complete value as a single string in json.

Replace

```json
{
  "dyalog-mode": {
    "fetcher": "bitbucket",
    "repo": "harsman/dyalog-mode",
    "files": {
      "defaults": "Emacs.apl"
    }
  }
}
```

(which is invalid) with

```json
{
  "dyalog-mode": {
    "fetcher": "bitbucket",
    "repo": "harsman/dyalog-mode",
    "files": "(:defaults \"Emacs.apl\")"
  }
}
```

@conao3 Do you actually have to extract the value of `:files` out of the json file? Unless someone actually needs to get this data from there I see no reason to go through all the trouble that encoding this in json would bring with it. (I don't think your proposed pr would be sufficient.)