### PR TITLE
package-build--create-tar: don't fiddle with windows filenames

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -362,8 +362,6 @@ is used instead."
 
 (defun package-build--create-tar (file dir &optional files)
   "Create a tar FILE containing the contents of DIR, or just FILES if non-nil."
-  (when (eq system-type 'windows-nt)
-    (setq file (replace-regexp-in-string "^\\([a-z]\\):" "/\\1" file)))
   (apply 'process-file
          package-build-tar-executable nil
          (get-buffer-create "*package-build-checkout*")


### PR DESCRIPTION
Windows 10 ships a native version of tar:
https://techcommunity.microsoft.com/t5/Containers/Tar-and-Curl-Come-to-Windows/ba-p/382409

Also GNU tar on Windows uses native filenames.

I'm not able to build packages on Windows without this commit:

```
a fsharp-mode-20191130.1857
a fsharp-mode-20191130.1857/eglot-fsharp.el
a fsharp-mode-20191130.1857/fsharp-mode-font.el
a fsharp-mode-20191130.1857/fsharp-mode-pkg.el
a fsharp-mode-20191130.1857/fsharp-mode-structure.el
a fsharp-mode-20191130.1857/fsharp-mode-util.el
a fsharp-mode-20191130.1857/fsharp-mode.el
a fsharp-mode-20191130.1857/inf-fsharp-mode.el
Fetching origin
HEAD is now at 4a1df33 Merge pull request #230 from juergenhoetzel/changelog-update
tar.exe: Failed to open '/c/Users/pidsleywin/.emacs.d/.cask/26.3/bootstrap/packages/fsharp-mode-20191130.1857.tar'
```