### PR TITLE
method for package-recipe--working-tree

### DIFF
--- a/package-recipe.el
+++ b/package-recipe.el
@@ -52,8 +52,16 @@
   :abstract t)
 
 (defmethod package-recipe--working-tree ((rcp package-recipe))
-  (file-name-as-directory
-   (expand-file-name (oref rcp name) package-build-working-dir)))
+  (let* ((url (package-recipe--upstream-url rcp))
+         (basedir (s-replace ":" "" url))
+         (basedir (s-replace "//" "/" basedir)))
+    (file-name-as-directory
+     ;; Not using (oref rcp name) as
+     ;; multiple clone or checkout of same repository, in case multiple
+     ;; packages are from same repository
+
+     ;; (expand-file-name (oref rcp name) package-build-working-dir)
+     (expand-file-name basedir package-build-working-dir))))
 
 (defmethod package-recipe--upstream-url ((rcp package-recipe))
   (or (oref rcp url)


### PR DESCRIPTION
generate repository path based on package name, which is posing multiple
clone or sync from same repository if there are multiple packages present in
same repository, which in turn consuming lot of CPU and disk-space

Modified method package-recipe--working-tree
to generate path based on repository url, to overcome this issue.