### PR TITLE
Prevent fetching from git using an insecure protocol

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -156,6 +156,13 @@ The string in the capture group should be parsed as valid by `version-to-list'."
   :group 'package-build
   :type 'string)
 
+(defcustom package-build-allowed-git-protocols '("https" "file" "ssh")
+  "Protocols that can be used to fetch from upstream with git.
+By default insecure protocols, such as \"http\" or \"git\", are
+disallowed."
+  :group 'package-build
+  :type '(repeat string))
+
 ;;; Generic Utilities
 
 (defun package-build--message (format-string &rest args)
@@ -286,7 +293,10 @@ is used instead."
 
 (cl-defmethod package-build--checkout ((rcp package-git-recipe))
   (let ((dir (package-recipe--working-tree rcp))
-        (url (package-recipe--upstream-url rcp)))
+        (url (package-recipe--upstream-url rcp))
+        (protocol (package-recipe--upstream-protocol rcp)))
+    (unless (member protocol package-build-allowed-git-protocols)
+      (error "Fetching using the %s protocol is not allowed" protocol))
     (cond
      ((and (file-exists-p (expand-file-name ".git" dir))
            (string-equal (package-build--used-url rcp) url))

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -29,6 +29,7 @@
 ;;; Code:
 
 (require 'eieio)
+(require 'url-parse)
 
 (defvar package-build-recipes-dir)
 (defvar package-build-working-dir)
@@ -59,6 +60,13 @@
   (or (oref rcp url)
       (format (oref rcp url-format)
               (oref rcp repo))))
+
+(cl-defmethod package-recipe--upstream-protocol ((rcp package-recipe))
+  (let ((url (package-recipe--upstream-url rcp)))
+    (cond ((string-match "\\`\\([a-z]+\\)://" url)
+           (match-string 1 url))
+          ((string-match "\\`[^:/ ]+:" url) "ssh")
+          (t "file"))))
 
 (cl-defmethod package-recipe--fetcher ((rcp package-recipe))
   (substring (symbol-name (eieio-object-class rcp)) 8 -7))


### PR DESCRIPTION
(As suggested [here](https://github.com/melpa/melpa/issues/3004#issuecomment-726186921).)

This is to prevent https://github.com/melpa/melpa/issues/3004 from coming up again.

I have no idea whether this is the cleanest approach, but it seems to work (allowing building packages that use `https:`, but not those that use `git:`), so hopefully with feedback it might be massaged into something useful.  (That is assuming that making changes in `package-build` is not deemed to be an overkill for the issue.)

### `hg`

I have not touched the checkout code for mercurial, since I have very little experience with `hg`, and hence I'm not sure which protocols should be allowed. Obviously, the same approach would also work for it.

### `file` and `ssh` protocols

I've kept the "file" and "ssh" protocols, in addition to the obvious ("https").  I remember specifying a local path in a recipe, for local testing, in the distant past, so I think the `file` protocol (used implicitly or explicitly) should definitely be kept; anyway, it's not insecure.  I'm less sure about `ssh` — in principle `ssh`'s TOFU provides some security, but probably not in an automated environment (MELPA's servers).

<hr/>

In the highly unlikely case that this is ready as-is, merging should presumably wait until the several packages now fetching over `git://` and `http://` switch over.   Alternatively, these several recipes could be "grandfathered in" via a kludge (checking for the names of these packages).