### PR TITLE
convert package name to string

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -346,7 +346,7 @@ is used instead."
 ;;; Generate Files
 
 (defun package-build--write-pkg-file (desc dir)
-  (let ((name (package-desc-name desc)))
+  (let ((name (symbol-name (package-desc-name desc))))
     (with-temp-file (expand-file-name (format "%s-pkg.el" name) dir)
       (pp `(define-package ,name
              ,(package-version-join (package-desc-version desc))


### PR DESCRIPTION
package-build generates `define-package` expressions with bare symbols where strings are required: the `define-package` docstring states
> NAME-STRING is the name of the package, as a string.

however, the docstring for `package-desc` states
> `name'	Name of the package, as a symbol.

so we must convert the symbol from this slot to a string

fixes melpa/melpa#7312