### PR TITLE
Fix erroneous comment.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -399,9 +399,9 @@ is used instead."
                 (and (file-exists-p file)
                      (lm-commentary file)))))
     (with-temp-buffer
-      (if (>= emacs-major-version 27)
+      (if (>= emacs-major-version 28)
           (insert commentary)
-        ;; Taken from 27.1's `lm-commentary'.
+        ;; Taken from 28.0's `lm-commentary'.
         (insert
          (replace-regexp-in-string       ; Get rid of...
           "[[:blank:]]*$" ""             ; trailing white-space


### PR DESCRIPTION
The sanitization code in question is actually taken from Emacs 28. The
corresponding Emacs commit is 963a9ffd66cb29f0370e9a4b854dddda242c54a6,
which is not in the Emacs 27 branch.