### PR TITLE
Strip at most one leading space from package commentaries.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -411,7 +411,7 @@ is used instead."
                    (concat "^;;;[[:blank:]]*\\("
                            lm-commentary-header
                            "\\):[[:blank:]\n]*")
-                   "^;;[[:blank:]]*"     ; double semicolon prefix
+                   "^;;[[:blank:]]?"     ; double semicolon prefix
                    "[[:blank:]\n]*\\'")  ; trailing new-lines
            "" commentary))))
       (unless (or (bobp) (= (char-before) ?\n))


### PR DESCRIPTION
This back ports commit 9c1e89a32c65244a992a8a1ff73fd606f94a8a15 from the
Emacs repository.