### PR TITLE
Add a new option package-build-get-version-function

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -219,11 +219,6 @@ is used instead."
             (error "Command '%s' exited with non-zero status %d: %s"
                    argv exit-code (buffer-string)))))))
 
-(defun package-build--process-lines (directory command &rest args)
-  (with-temp-buffer
-    (apply 'package-build--run-process directory t command args)
-    (split-string (buffer-string) "\n" t)))
-
 ;;; Checkout
 ;;;; Common
 
@@ -283,10 +278,10 @@ is used instead."
     (process-lines "git" "tag")))
 
 (cl-defmethod package-build--get-timestamp ((rcp package-git-recipe))
-  (car (apply #'package-build--process-lines
-              (package-recipe--working-tree rcp)
-              "git" "log" "--first-parent" "-n1" "--pretty=format:'\%ci'"
-              (package-build--expand-source-file-list rcp))))
+  (let ((default-directory (package-recipe--working-tree rcp)))
+    (car (apply #'process-lines
+                "git" "log" "--first-parent" "-n1" "--pretty=format:'\%ci'"
+                (package-build--expand-source-file-list rcp)))))
 
 (cl-defmethod package-build--used-url ((rcp package-git-recipe))
   (let ((default-directory (package-recipe--working-tree rcp)))
@@ -333,10 +328,10 @@ is used instead."
             (process-lines "hg" "tags"))))
 
 (cl-defmethod package-build--get-timestamp ((rcp package-hg-recipe))
-  (car (apply #'package-build--process-lines
-              (package-recipe--working-tree rcp)
-              "hg" "log" "--style" "compact" "-l1"
-              (package-build--expand-source-file-list rcp))))
+  (let ((default-directory (package-recipe--working-tree rcp)))
+    (car (apply #'process-lines
+                "hg" "log" "--style" "compact" "-l1"
+                (package-build--expand-source-file-list rcp)))))
 
 (cl-defmethod package-build--used-url ((rcp package-hg-recipe))
   (let ((default-directory (package-recipe--working-tree rcp)))

--- a/package-build.el
+++ b/package-build.el
@@ -313,11 +313,17 @@ is used instead."
                  (package-build--list-tags rcp)
                  (oref rcp version-regexp))
                 (error "No valid stable versions found for %s" (oref rcp name)))
-          (package-build--run-process dir nil "hg" "update" tag)
+          (package-build--checkout-1 rcp tag)
           version)
+      (package-build--checkout-1 rcp)
       (package-build--parse-time
        (package-build--get-timestamp rcp)
        (oref rcp tag-regexp)))))
+
+(cl-defmethod package-build--checkout-1 ((rcp package-hg-recipe) &optional rev)
+  (when rev
+    (package-build--run-process (package-recipe--working-tree rcp)
+                                nil "hg" "update" rev)))
 
 (cl-defmethod package-build--list-tags ((rcp package-hg-recipe))
   (let ((default-directory (package-recipe--working-tree rcp)))

--- a/package-build.el
+++ b/package-build.el
@@ -169,7 +169,7 @@ Otherwise do nothing.  FORMAT-STRING and ARGS are as per that function."
   (cons (package-build--get-commit rcp)
         (package-build--parse-time
          (package-build--get-timestamp rcp)
-         (oref rcp tag-regexp))))
+         (oref rcp time-regexp))))
 
 ;;;; Internal
 

--- a/package-build.el
+++ b/package-build.el
@@ -349,9 +349,9 @@ is used instead."
               (package-build--expand-source-file-list rcp))))
 
 (cl-defmethod package-build--used-url ((rcp package-hg-recipe))
-  (package-build--run-process-match "default = \\(.*\\)"
+  (package-build--run-process-match "\\(.*\\)"
                                     (package-recipe--working-tree rcp)
-                                    "hg" "paths"))
+                                    "hg" "paths" "default"))
 
 (cl-defmethod package-build--get-commit ((rcp package-hg-recipe))
   (ignore-errors

--- a/package-build.el
+++ b/package-build.el
@@ -151,13 +151,14 @@ Otherwise do nothing.  FORMAT-STRING and ARGS are as per that function."
       (error "No valid stable versions found for %s" (oref rcp name)))
     (when (cl-typep rcp 'package-git-recipe)
       (setq tag (concat "tags/" tag)))
-    (cons tag
+    (cons (package-build--get-commit rcp tag)
           version)))
 
 (defun package-build-get-timestamp-version (rcp)
-  (package-build--parse-time
-   (package-build--get-timestamp rcp)
-   (oref rcp tag-regexp)))
+  (cons (package-build--get-commit rcp)
+        (package-build--parse-time
+         (package-build--get-timestamp rcp)
+         (oref rcp tag-regexp))))
 
 ;;;; Internal
 
@@ -274,7 +275,7 @@ is used instead."
           (package-build--checkout-1 rcp tag)
           version)
       (package-build--checkout-1 rcp)
-      (package-build-get-timestamp-version rcp))))
+      (cdr (package-build-get-timestamp-version rcp)))))
 
 (cl-defmethod package-build--checkout-1 ((rcp package-git-recipe) &optional rev)
   (let ((dir (package-recipe--working-tree rcp)))
@@ -328,7 +329,7 @@ is used instead."
           (package-build--checkout-1 rcp tag)
           version)
       (package-build--checkout-1 rcp)
-      (package-build-get-timestamp-version rcp))))
+      (cdr (package-build-get-timestamp-version rcp)))))
 
 (cl-defmethod package-build--checkout-1 ((rcp package-hg-recipe) &optional rev)
   (when rev

--- a/package-build.el
+++ b/package-build.el
@@ -249,11 +249,12 @@ is used instead."
                                   "--filter=blob:none" "--no-checkout"
                                   url dir)))
     (if package-build-stable
-        (cl-destructuring-bind (tag . version)
-            (or (package-build--find-version-newest
-                 (package-build--list-tags rcp)
-                 (oref rcp version-regexp))
-                (error "No valid stable versions found for %s" (oref rcp name)))
+        (pcase-let ((`(,tag . ,version)
+                     (or (package-build--find-version-newest
+                          (package-build--list-tags rcp)
+                          (oref rcp version-regexp))
+                         (error "No valid stable versions found for %s"
+                                (oref rcp name)))))
           (package-build--checkout-1 rcp (concat "tags/" tag))
           version)
       (package-build--checkout-1 rcp)
@@ -308,11 +309,12 @@ is used instead."
       (package-build--message "Cloning %s to %s" url dir)
       (package-build--run-process nil nil "hg" "clone" url dir)))
     (if package-build-stable
-        (cl-destructuring-bind (tag . version)
-            (or (package-build--find-version-newest
-                 (package-build--list-tags rcp)
-                 (oref rcp version-regexp))
-                (error "No valid stable versions found for %s" (oref rcp name)))
+        (pcase-let ((`(,tag . ,version)
+                     (or (package-build--find-version-newest
+                          (package-build--list-tags rcp)
+                          (oref rcp version-regexp))
+                         (error "No valid stable versions found for %s"
+                                (oref rcp name)))))
           (package-build--checkout-1 rcp tag)
           version)
       (package-build--checkout-1 rcp)

--- a/package-build.el
+++ b/package-build.el
@@ -356,9 +356,10 @@ is used instead."
 (cl-defmethod package-build--get-commit ((rcp package-hg-recipe))
   (ignore-errors
     (package-build--run-process-match
-     "changeset:[[:space:]]+[[:digit:]]+:\\([[:xdigit:]]+\\)"
+     "\\(.*\\)"
      (package-recipe--working-tree rcp)
-     "hg" "log" "--debug" "--limit=1")))
+     ;; "--debug" is needed to get the full hash.
+     "hg" "--debug" "id" "-i")))
 
 ;;; Generate Files
 

--- a/package-build.el
+++ b/package-build.el
@@ -266,9 +266,14 @@ is used instead."
       (when (file-exists-p dir)
         (delete-directory dir t))
       (package-build--message "Cloning %s to %s" url dir)
-      (package-build--run-process nil nil "git" "clone"
-                                  "--filter=blob:none" "--no-checkout"
-                                  url dir)))
+      (apply #'package-build--run-process nil nil "git" "clone" url dir
+             ;; This can dramatically reduce the size of large repos.
+             ;; But we can only do this when using a version function
+             ;; that is known not to require a checkout and history.
+             ;; See #52.
+             (and (eq package-build-get-version-function
+                      'package-build-get-tag-version)
+                  (list "--filter=blob:none" "--no-checkout")))))
     (if package-build-stable
         (pcase-let ((`(,tag . ,version)
                      (package-build-get-tag-version rcp)))

--- a/package-build.el
+++ b/package-build.el
@@ -287,9 +287,9 @@ is used instead."
   (let ((default-directory (package-recipe--working-tree rcp)))
     (car (process-lines "git" "config" "remote.origin.url"))))
 
-(cl-defmethod package-build--get-commit ((rcp package-git-recipe))
+(cl-defmethod package-build--get-commit ((rcp package-git-recipe) &optional rev)
   (let ((default-directory (package-recipe--working-tree rcp)))
-    (car (process-lines "git" "rev-parse" "HEAD"))))
+    (car (process-lines "git" "rev-parse" (or rev "HEAD")))))
 
 ;;;; Hg
 
@@ -343,10 +343,12 @@ is used instead."
   (let ((default-directory (package-recipe--working-tree rcp)))
     (car (process-lines "hg" "paths" "default"))))
 
-(cl-defmethod package-build--get-commit ((rcp package-hg-recipe))
+(cl-defmethod package-build--get-commit ((rcp package-hg-recipe) &optional rev)
   (let ((default-directory (package-recipe--working-tree rcp)))
     ;; "--debug" is needed to get the full hash.
-    (car (process-lines "hg" "--debug" "id" "-i"))))
+    (car (apply #'process-lines "hg" "--debug" "id" "-i"
+                (and rev (list rev))))))
+
 
 ;;; Generate Files
 

--- a/package-build.el
+++ b/package-build.el
@@ -266,9 +266,7 @@ is used instead."
           version)
       (package-build--checkout-1 rcp)
       (package-build--parse-time
-       (car (apply #'package-build--process-lines dir
-                   "git" "log" "--first-parent" "-n1" "--pretty=format:'\%ci'"
-                   (package-build--expand-source-file-list rcp)))
+       (package-build--get-timestamp rcp)
        (oref rcp tag-regexp)))))
 
 (cl-defmethod package-build--checkout-1 ((rcp package-git-recipe) &optional rev)
@@ -290,6 +288,12 @@ is used instead."
 (cl-defmethod package-build--list-tags ((rcp package-git-recipe))
   (let ((default-directory (package-recipe--working-tree rcp)))
     (process-lines "git" "tag")))
+
+(cl-defmethod package-build--get-timestamp ((rcp package-git-recipe))
+  (car (apply #'package-build--process-lines
+              (package-recipe--working-tree rcp)
+              "git" "log" "--first-parent" "-n1" "--pretty=format:'\%ci'"
+              (package-build--expand-source-file-list rcp))))
 
 (cl-defmethod package-build--used-url ((rcp package-git-recipe))
   (let ((default-directory (package-recipe--working-tree rcp)))
@@ -327,9 +331,7 @@ is used instead."
           (package-build--run-process dir nil "hg" "update" tag)
           version)
       (package-build--parse-time
-       (car (apply #'package-build--process-lines dir
-                   "hg" "log" "--style" "compact" "-l1"
-                   (package-build--expand-source-file-list rcp)))
+       (package-build--get-timestamp rcp)
        (oref rcp tag-regexp)))))
 
 (cl-defmethod package-build--list-tags ((rcp package-hg-recipe))
@@ -339,6 +341,12 @@ is used instead."
               (string-match "\\`[^ ]+" line)
               (match-string 0))
             (process-lines "hg" "tags"))))
+
+(cl-defmethod package-build--get-timestamp ((rcp package-hg-recipe))
+  (car (apply #'package-build--process-lines
+              (package-recipe--working-tree rcp)
+              "hg" "log" "--style" "compact" "-l1"
+              (package-build--expand-source-file-list rcp))))
 
 (cl-defmethod package-build--used-url ((rcp package-hg-recipe))
   (package-build--run-process-match "default = \\(.*\\)"

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -38,7 +38,7 @@
 (defclass package-recipe ()
   ((url-format      :allocation :class       :initform nil)
    (repopage-format :allocation :class       :initform nil)
-   (tag-regexp      :allocation :class       :initform nil)
+   (time-regexp     :allocation :class       :initform nil)
    (stable-p        :allocation :class       :initform nil)
    (name            :initarg :name           :initform nil)
    (url             :initarg :url            :initform nil)
@@ -66,7 +66,7 @@
 ;;;; Git
 
 (defclass package-git-recipe (package-recipe)
-  ((tag-regexp      :initform "\
+  ((time-regexp     :initform "\
 \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
 [0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))
 
@@ -81,7 +81,7 @@
 ;;;; Mercurial
 
 (defclass package-hg-recipe (package-recipe)
-  ((tag-regexp      :initform "\
+  ((time-regexp     :initform "\
 \\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\} \
 [0-9]\\{2\\}:[0-9]\\{2\\}\\( [+-][0-9]\\{4\\}\\)?\\)")))
 


### PR DESCRIPTION
This new option allows anyone to implement their own version scheme, without having to modify `package-build.el`. Or at least that is the idea; I have done exactly zero testing so far. The interesting part of course is to implement such a scheme and I still plan to implement one that is similar, but not identical, to the one @purcell suggested a long time ago. But unfortunately I have used up the time I have allocated for this with these preparations, so the real thing (and the testing) will have to wait until the next weekend at least.