### PR TITLE
Clone git repos without blobs initially

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -253,7 +253,7 @@ is used instead."
       (when (file-exists-p dir)
         (delete-directory dir t))
       (package-build--message "Cloning %s to %s" url dir)
-      (package-build--run-process nil nil "git" "clone" url dir)))
+      (package-build--run-process nil nil "git" "clone" "--filter=blob:none" "--no-checkout" url dir)))
     (if package-build-stable
         (cl-destructuring-bind (tag . version)
             (or (package-build--find-version-newest


### PR DESCRIPTION
This can dramatically reduce the size of large repos, see

https://github.com/melpa/melpa/issues/5361
https://github.com/melpa/melpa/issues/7524

- We always checkout or reset the repo before building, at which point blobs will be fetched lazily
- History of individual files still works

Presumably, over time, some sort of gc on long-lived checked-out working directories will also be desirable.