### PR TITLE
Make sure the version regexp matches the tag.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -229,8 +229,10 @@ If optional REGEXP is nil, then `package-build-version-regexp'
 is used instead."
   (let ((ret '(nil 0)))
     (dolist (tag tags)
-      (string-match (or regexp package-build-version-regexp) tag)
-      (let ((version (ignore-errors (version-to-list (match-string 1 tag)))))
+      (let* ((version-string (and (string-match
+                                   (or regexp package-build-version-regexp) tag)
+                                  (match-string 1 tag)))
+             (version (ignore-errors (version-to-list version-string))))
         (when (and version (version-list-<= (cdr ret) version))
           (setq ret (cons tag version))))
       ;; Some version tags use "_" as version separator instead of
@@ -240,8 +242,10 @@ is used instead."
       ;; `version-regexp-alist', we don't have to worry about the
       ;; incorrect version list above `(1 -4 4 -4 5)' since it will
       ;; always be treated as smaller by `version-list-<'.
-      (string-match (or regexp package-build-version-regexp) tag)
-      (let* ((version-separator "_")
+      (let* ((version-string (and (string-match
+                                   (or regexp package-build-version-regexp) tag)
+                                  (match-string 1 tag)))
+             (version-separator "_")
              (version (ignore-errors (version-to-list (match-string 1 tag)))))
         (when (and version (version-list-<= (cdr ret) version))
           (setq ret (cons tag version)))))

--- a/package-build.el
+++ b/package-build.el
@@ -227,28 +227,25 @@ parses the first match group instead of STR."
   "Find the newest version in TAGS matching REGEXP.
 If optional REGEXP is nil, then `package-build-version-regexp'
 is used instead."
-  (let ((ret '(nil 0)))
-    (dolist (tag tags)
-      (let* ((version-string (and (string-match
-                                   (or regexp package-build-version-regexp) tag)
-                                  (match-string 1 tag)))
-             (version (ignore-errors (version-to-list version-string))))
-        (when (and version (version-list-<= (cdr ret) version))
-          (setq ret (cons tag version))))
-      ;; Some version tags use "_" as version separator instead of
-      ;; the default ".", e.g. "1_4_5".  Check for valid versions
-      ;; again, this time using "_" as a `version-separator'.
-      ;; Since "_" is otherwise treated as a snapshot separator by
-      ;; `version-regexp-alist', we don't have to worry about the
-      ;; incorrect version list above `(1 -4 4 -4 5)' since it will
-      ;; always be treated as smaller by `version-list-<'.
-      (let* ((version-string (and (string-match
-                                   (or regexp package-build-version-regexp) tag)
-                                  (match-string 1 tag)))
-             (version-separator "_")
-             (version (ignore-errors (version-to-list version-string))))
-        (when (and version (version-list-<= (cdr ret) version))
-          (setq ret (cons tag version)))))
+  (let ((ret '(nil 0))
+        (regexp (or regexp package-build-version-regexp)))
+    (cl-flet ((match (regexp separator tag)
+                (let* ((version-string (and (string-match regexp tag)
+                                            (match-string 1 tag)))
+                       (version-seperator separator)
+                       (version (ignore-errors (version-to-list version-string))))
+                  (when (and version (version-list-<= (cdr ret) version))
+                    (setq ret (cons tag version))))))
+      (dolist (tag tags)
+        (match regexp "." tag)
+        ;; Some version tags use "_" as version separator instead of
+        ;; the default ".", e.g. "1_4_5".  Check for valid versions
+        ;; again, this time using "_" as a `version-separator'.
+        ;; Since "_" is otherwise treated as a snapshot separator by
+        ;; `version-regexp-alist', we don't have to worry about the
+        ;; incorrect version list above `(1 -4 4 -4 5)' since it will
+        ;; always be treated as smaller by `version-list-<'.
+        (match regexp "_" tag)))
     (and (car ret)
          (cons (car ret)
                (package-version-join (cdr ret))))))

--- a/package-build.el
+++ b/package-build.el
@@ -246,7 +246,7 @@ is used instead."
                                    (or regexp package-build-version-regexp) tag)
                                   (match-string 1 tag)))
              (version-separator "_")
-             (version (ignore-errors (version-to-list (match-string 1 tag)))))
+             (version (ignore-errors (version-to-list version-string))))
         (when (and version (version-list-<= (cdr ret) version))
           (setq ret (cons tag version)))))
     (and (car ret)


### PR DESCRIPTION
Before this change, for some reason unknown to me, if the
`string-match` failed, the call to `match-string` would still return a
result. A tag `0.16.0` with a regexp of `foo/v\\(.*\\)` was failing to
match but was still return `0.16.` as a result for the call to
`match-string`.

With this change, `match-string` isn't even called if there is no
string match.

This is related to melpa/melpa#7821