### PR TITLE
Checkout configurable tag

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -175,16 +175,19 @@ Otherwise do nothing.  FORMAT-STRING and ARGS are as per that function."
 ;;;; Public
 
 (defun package-build-get-tag-version (rcp)
-  (pcase-let ((`(,tag . ,version)
+  (pcase-let ((`(,newest-tag . ,newest-version)
                (package-build--find-version-newest
                 (package-build--list-tags rcp)
                 (oref rcp version-regexp))))
-    (unless tag
-      (error "No valid stable versions found for %s" (oref rcp name)))
-    (when (cl-typep rcp 'package-git-recipe)
-      (setq tag (concat "tags/" tag)))
-    (cons (package-build--get-commit rcp tag)
-          version)))
+    (let* ((rcp-tag (oref rcp tag))
+           (tag (or rcp-tag newest-tag))
+           (version (or rcp-tag newest-version)))
+      (unless tag
+        (error "No valid stable versions found for %s" (oref rcp name)))
+      (when (cl-typep rcp 'package-git-recipe)
+        (setq tag (concat "tags/" tag)))
+      (cons (package-build--get-commit rcp tag)
+            version))))
 
 (defun package-build-get-timestamp-version (rcp)
   (let ((rev (and (cl-typep rcp 'package-git-recipe)

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -49,7 +49,8 @@
    (branch          :initarg :branch         :initform nil)
    (commit          :initarg :commit         :initform nil)
    (version-regexp  :initarg :version-regexp :initform nil)
-   (old-names       :initarg :old-names      :initform nil))
+   (old-names       :initarg :old-names      :initform nil)
+   (tag             :initarg :tag            :initform nil))
   :abstract t)
 
 (cl-defmethod package-recipe--working-tree ((rcp package-recipe))
@@ -137,7 +138,7 @@ file is invalid, then raise an error."
                name ident)
     (cl-assert plist)
     (let* ((symbol-keys '(:fetcher))
-           (string-keys '(:url :repo :commit :branch :version-regexp))
+           (string-keys '(:url :repo :commit :branch :version-regexp :tag))
            (list-keys '(:files :old-names))
            (all-keys (append symbol-keys string-keys list-keys)))
       (dolist (thing plist)


### PR DESCRIPTION
I have expanded the recipes to include a tag options to let me build packages of targeted releases.
I'm kinda new to Emacs so the code might not be idiomatic, or a better solution exists that isn't documented.

At least this is my naive attempt, and it seems to work without problem.

### Rationale

I run openSUSE which contains an older packages of Emacs (25.3). on Emacs homepage the official way is to use the distributions supplied version. I want to work with Clojure and run CIDER.
CIDER supports emacs25 from MELPA stable, but dependencies of CIDER have emacs26 as latest supported version. Instead of downloading Github repositories and loading packages it would be neater to setup a custom MELPA with predefined version of packages.