### PR TITLE
Set file timestamps to reproducible value.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -828,6 +828,14 @@ in `package-build-archive-dir'."
           (package-build--copy-package-files files source-dir target)
           (package-build--write-pkg-file desc target)
           (package-build--generate-info-files files source-dir target)
+          (let ((tstamp (replace-regexp-in-string
+                         "\\." ""
+                         (package-build--parse-time
+                          (package-build--get-timestamp rcp commit)
+                          (oref rcp time-regexp)))))
+            (package-build--run-process tmp-dir nil
+                                        "find" "." "-exec" "touch" "-t"
+                                        tstamp "\{\}" "\;"))
           (package-build--create-tar name version tmp-dir)
           (package-build--write-pkg-readme name files source-dir)
           (package-build--write-archive-entry desc))


### PR DESCRIPTION
The goal is to produce hash-identical archives whenever the source did not
change. Previously timestamps caused this to fail as they are recorded in
the tar archive. Now we set the timestamps of all files to the timestamp of
the commit they are from.

This superseedes https://github.com/melpa/melpa/pull/8030 .