### PR TITLE
Add and remove default files spec entries

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -648,11 +648,14 @@ still be renamed."
 ;;; File Specs
 
 (defconst package-build-default-files-spec
-  '("*.el"
+  '("*.el" "lisp/*.el"
     "dir" "*.info" "*.texi" "*.texinfo"
     "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
     "docs/dir" "docs/*.info" "docs/*.texi" "docs/*.texinfo"
-    (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"))
+    (:exclude
+     ".dir-locals.el" "lisp/.dir-locals.el"
+     "test.el" "tests.el" "*-test.el" "*-tests.el"
+     "lisp/test.el" "lisp/tests.el" "lisp/*-test.el" "lisp/*-tests.el"))
   "Default value for :files attribute in recipes.")
 
 (defun package-build-expand-file-specs (dir specs &optional subdir allow-empty)

--- a/package-build.el
+++ b/package-build.el
@@ -648,8 +648,8 @@ still be renamed."
 ;;; File Specs
 
 (defconst package-build-default-files-spec
-  '("*.el" "*.el.in" "dir"
-    "*.info" "*.texi" "*.texinfo"
+  '("*.el"
+    "dir" "*.info" "*.texi" "*.texinfo"
     "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
     "docs/dir" "docs/*.info" "docs/*.texi" "docs/*.texinfo"
     (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"))


### PR DESCRIPTION
- Remove `"*.el.in"`.  There are only two packages that benefited from this
  entry and quite a few more packages that had to undo it.

- Add `"lisp/*.el"` and corresponding `:exclude` entries.  There are fewer
  packages that benefit from this change than I would have expected, but still
  enough to justify this addition.

I have carefully inspected the effect of these changes to determine whether the
resulting differences are desired.  In the few cases where that was not the case
I have adjusted the recipe of the affected package.

See https://github.com/melpa/melpa/pull/8032 for the changes to the recipes.