### PR TITLE
Synchronize commit and timestamp information.

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -399,7 +399,6 @@ is used instead."
 
 (cl-defmethod package-build--get-commit ((rcp package-hg-recipe) &optional rev)
   (let ((default-directory (package-recipe--working-tree rcp)))
-    ;; "--debug" is needed to get the full hash.
     (car (apply #'process-lines
                 "hg" "log" "--limit" "1" "--template" "{node}\n"
                 `(,@(and rev (list "--rev" rev))


### PR DESCRIPTION
The functions package-build--get-commit and package-build--get-timestamp
are used to determine what snapshot is used for building a package
archive. However they use deviating methods to determine this
information resulting in conflicting information. Here we transplant the
mechanics from package-build--get-timestamp to package-build--get-commit
to establish a coherent state.

This is a step towards reproducible distfiles.

This should make no functional difference.