### PR TITLE
Fix package-build--ensure-ends-here-line

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -545,8 +545,10 @@ still be renamed."
   "Add the \"FILE ends here\" trailing line if it is missing."
   (save-excursion
     (goto-char (point-min))
-    (let ((trailer (format "^;;; %s ends here" (file-name-nondirectory file))))
-      (unless (search-forward trailer nil t)
+    (let ((trailer (format ";;; %s ends here" (file-name-nondirectory file))))
+      (unless (re-search-forward
+               (format "^%s" (regexp-quote trailer))
+               nil t)
         (goto-char (point-max))
         (insert ?\n trailer ?\n)))))
 


### PR DESCRIPTION
After https://github.com/melpa/package-build/commit/f9dfe309e5135119145c224e59d165e7b1d9179f `package-build--ensure-ends-here-line` started adding unnecessary `^` before `;;; <package>.el ends here`, like this:
```lisp
;;; org-journal-tags.el ends here

^;;; org-journal-tags.el ends here
```
Which creates an error with `^` referencing a free variable.

This PR fixes that.