### PR TITLE
Clearly separate fetching, version detection and checking out

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -624,15 +624,6 @@ still be renamed."
      "lisp/test.el" "lisp/tests.el" "lisp/*-test.el" "lisp/*-tests.el"))
   "Default value for :files attribute in recipes.")
 
-(defun package-build-expand-file-specs (repo spec &optional subdir allow-empty)
-  (when subdir
-    (error "%s: Non-nil SUBDIR is no longer supported"
-           'package-build-expand-file-specs))
-  (package-build-expand-files-spec nil (not allow-empty) repo spec))
-(make-obsolete 'package-build-expand-file-specs
-               'package-build-expand-files-spec
-               "Package-Build 3.2")
-
 (defun package-build-expand-files-spec (rcp &optional assert repo spec)
   "Return an alist of files of package RCP to be included in tarball.
 
@@ -675,9 +666,7 @@ order and can have the following form:
   matched by earlier elements that are also matched by the second
   and subsequent elements of this list to be removed from the
   returned alist.  Files matched by later elements are not
-  affected.
-
-\(fn RCP &optional ASSERT)" ; Other arguments only for backward compat.
+  affected."
   (let ((default-directory (or repo (package-recipe--working-tree rcp)))
         (spec (or spec (oref rcp files))))
     (when (eq (car spec) :defaults)
@@ -1061,9 +1050,6 @@ line per entry."
     (insert (json-encode (package-build--archive-alist-for-json)))))
 
 ;;; _
-
-(define-obsolete-function-alias 'package-build--archive-entries
-  #'package-build-dump-archive-contents "Package-Build 3.0")
 
 (provide 'package-build)
 ;;; package-build.el ends here

--- a/package-build.el
+++ b/package-build.el
@@ -522,7 +522,23 @@ still be renamed."
 
 ;;; Package Structs
 
-(defun package-build--desc-from-library (rcp files &optional type)
+(defun package-build--desc-from-library (rcp files &optional kind)
+  "Return the package description for RCP.
+
+This function is used for all packages that consist of a single
+file and those packages that consist of multiple files but lack
+a file named \"NAME-pkg.el\" or \"NAME-pkg.el\".
+
+The returned value is a `package-desc' struct (which see).
+The values of the `name' and `version' slots are taken from RCP
+itself.  The value of `kind' is taken from the KIND argument,
+which defaults to `single'; the other valid value being `tar'.
+
+Other information is taken from the file named \"NAME-pkg.el\",
+which should appear in FILES.  As a fallback, \"NAME-pkg.el.in\"
+is also tried.  If neither file exists, then return nil.  If a
+value is not specified in the used file, then fall back to the
+value specified in the file \"NAME.el\"."
   (let* ((name (oref rcp name))
          (version (oref rcp version))
          (commit (oref rcp commit))
@@ -543,7 +559,7 @@ still be renamed."
             (when-let ((require-lines (lm-header-multiline "package-requires")))
               (package--prepare-dependencies
                (package-read-from-string (mapconcat #'identity require-lines " "))))
-            :kind       (or type 'single)
+            :kind       (or kind 'single)
             :url        (lm-homepage)
             :keywords   (lm-keywords-list)
             :maintainer (if (fboundp 'lm-maintainers)
@@ -554,6 +570,17 @@ still be renamed."
             :commit     commit)))))
 
 (defun package-build--desc-from-package (rcp files)
+  "Return the package description for RCP.
+
+This function is used for packages that consist of multiple files.
+
+The returned value is a `package-desc' struct (which see).
+The values of the `name' and `version' slots are taken from RCP
+itself.  The value of `kind' is always `tar'.
+
+Other information is taken from the file named \"NAME.el\",
+which should appear in FILES.  As a fallback, \"NAME.el.in\"
+is also tried.  If neither file exists, then return nil."
   (let* ((name (oref rcp name))
          (version (oref rcp version))
          (commit (oref rcp commit))

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -47,6 +47,8 @@
    (files           :initarg :files          :initform nil)
    (branch          :initarg :branch         :initform nil)
    (commit          :initarg :commit         :initform nil)
+   (time                                     :initform nil)
+   (version                                  :initform nil)
    (version-regexp  :initarg :version-regexp :initform nil)
    (old-names       :initarg :old-names      :initform nil))
   :abstract t)


### PR DESCRIPTION
This is the first in a series of pull-requests leading up to the implementation of a new version number scheme.  The changes in these commits are not directly related to the new scheme, but they are required to implement that.

Some of these changes are breaking changes.  For that reason I suggest that we do not merge this into `master` until we also merge the new version number scheme, to avoid making several breaking changes that downstream have to adjust to in quick succession.

However, it would IMO be a good idea to start using these changes on Melpa itself.  If there happen to be regressions, then it would be good to discover and fix these before the big switch to the new version number scheme.

Most of the breaking changes in these commits concern internal functions.  (But in the past we had learned that some downstream project use internal functions directly, so we still have to be careful.)