### PR TITLE
Use git/hg to determine correct commit for snapshot

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -624,15 +624,6 @@ still be renamed."
      "lisp/test.el" "lisp/tests.el" "lisp/*-test.el" "lisp/*-tests.el"))
   "Default value for :files attribute in recipes.")
 
-(defun package-build-expand-file-specs (repo spec &optional subdir allow-empty)
-  (when subdir
-    (error "%s: Non-nil SUBDIR is no longer supported"
-           'package-build-expand-file-specs))
-  (package-build-expand-files-spec nil (not allow-empty) repo spec))
-(make-obsolete 'package-build-expand-file-specs
-               'package-build-expand-files-spec
-               "Package-Build 3.2")
-
 (defun package-build-expand-files-spec (rcp &optional assert repo spec)
   "Return an alist of files of package RCP to be included in tarball.
 
@@ -675,9 +666,7 @@ order and can have the following form:
   matched by earlier elements that are also matched by the second
   and subsequent elements of this list to be removed from the
   returned alist.  Files matched by later elements are not
-  affected.
-
-\(fn RCP &optional ASSERT)" ; Other arguments only for backward compat.
+  affected."
   (let ((default-directory (or repo (package-recipe--working-tree rcp)))
         (spec (or spec (oref rcp files))))
     (when (eq (car spec) :defaults)
@@ -1061,9 +1050,6 @@ line per entry."
     (insert (json-encode (package-build--archive-alist-for-json)))))
 
 ;;; _
-
-(define-obsolete-function-alias 'package-build--archive-entries
-  #'package-build-dump-archive-contents "Package-Build 3.0")
 
 (provide 'package-build)
 ;;; package-build.el ends here

--- a/package-build.el
+++ b/package-build.el
@@ -522,7 +522,23 @@ still be renamed."
 
 ;;; Package Structs
 
-(defun package-build--desc-from-library (rcp files &optional type)
+(defun package-build--desc-from-library (rcp files &optional kind)
+  "Return the package description for RCP.
+
+This function is used for all packages that consist of a single
+file and those packages that consist of multiple files but lack
+a file named \"NAME-pkg.el\" or \"NAME-pkg.el\".
+
+The returned value is a `package-desc' struct (which see).
+The values of the `name' and `version' slots are taken from RCP
+itself.  The value of `kind' is taken from the KIND argument,
+which defaults to `single'; the other valid value being `tar'.
+
+Other information is taken from the file named \"NAME-pkg.el\",
+which should appear in FILES.  As a fallback, \"NAME-pkg.el.in\"
+is also tried.  If neither file exists, then return nil.  If a
+value is not specified in the used file, then fall back to the
+value specified in the file \"NAME.el\"."
   (let* ((name (oref rcp name))
          (version (oref rcp version))
          (commit (oref rcp commit))
@@ -543,7 +559,7 @@ still be renamed."
             (when-let ((require-lines (lm-header-multiline "package-requires")))
               (package--prepare-dependencies
                (package-read-from-string (mapconcat #'identity require-lines " "))))
-            :kind       (or type 'single)
+            :kind       (or kind 'single)
             :url        (lm-homepage)
             :keywords   (lm-keywords-list)
             :maintainer (if (fboundp 'lm-maintainers)
@@ -554,6 +570,17 @@ still be renamed."
             :commit     commit)))))
 
 (defun package-build--desc-from-package (rcp files)
+  "Return the package description for RCP.
+
+This function is used for packages that consist of multiple files.
+
+The returned value is a `package-desc' struct (which see).
+The values of the `name' and `version' slots are taken from RCP
+itself.  The value of `kind' is always `tar'.
+
+Other information is taken from the file named \"NAME.el\",
+which should appear in FILES.  As a fallback, \"NAME.el.in\"
+is also tried.  If neither file exists, then return nil."
   (let* ((name (oref rcp name))
          (version (oref rcp version))
          (commit (oref rcp commit))

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -198,11 +198,15 @@ file is invalid, then raise an error."
         ;; All other elements have to be strings or lists of strings.
         ;; A list whose first element is `:exclude' is also valid.
         (dolist (entry spec)
-          (unless (or (stringp entry)
+          (unless (or (and (stringp entry)
+                           (not (equal entry "*")))
                       (and (listp entry)
                            (or (eq (car entry) :exclude)
                                (stringp (car entry)))
-                           (seq-every-p #'stringp (cdr entry))))
+                           (seq-every-p (lambda (e)
+                                          (and (stringp e)
+                                               (not (equal e "*"))))
+                                        (cdr entry))))
             (error "Invalid files spec entry %S" entry))))
       ;; Silence byte compiler of Emacs 28.  It appears that uses
       ;; inside cl-assert sometimes, but not always, do not count.

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -47,6 +47,8 @@
    (files           :initarg :files          :initform nil)
    (branch          :initarg :branch         :initform nil)
    (commit          :initarg :commit         :initform nil)
+   (time                                     :initform nil)
+   (version                                  :initform nil)
    (version-regexp  :initarg :version-regexp :initform nil)
    (old-names       :initarg :old-names      :initform nil))
   :abstract t)

--- a/package-recipe.el
+++ b/package-recipe.el
@@ -147,6 +147,14 @@ file is invalid, then raise an error."
 
 ;;; Validation
 
+(defun package-recipe-validate-all ()
+  "Validate all recipes."
+  (interactive)
+  (dolist (name (package-recipe-recipes))
+    (condition-case err
+        (package-recipe-lookup name)
+      (error (message "Invalid recipe for %s: %S" name (cdr err))))))
+
 (defun package-recipe--validate (recipe name)
   "Perform some basic checks on the raw RECIPE for the package named NAME."
   (pcase-let ((`(,ident . ,plist) recipe))
@@ -182,6 +190,20 @@ file is invalid, then raise an error."
         (let ((val (plist-get plist key)))
           (when val
             (cl-assert (stringp val) nil "%s must be a string but is %S" key val))))
+      (when-let ((spec (plist-get plist :files)))
+        ;; `:defaults' is only allowed as the first element.
+        ;; If we find it in that position, skip over it.
+        (when (eq (car spec) :defaults)
+          (setq spec (cdr spec)))
+        ;; All other elements have to be strings or lists of strings.
+        ;; A list whose first element is `:exclude' is also valid.
+        (dolist (entry spec)
+          (unless (or (stringp entry)
+                      (and (listp entry)
+                           (or (eq (car entry) :exclude)
+                               (stringp (car entry)))
+                           (seq-every-p #'stringp (cdr entry))))
+            (error "Invalid files spec entry %S" entry))))
       ;; Silence byte compiler of Emacs 28.  It appears that uses
       ;; inside cl-assert sometimes, but not always, do not count.
       (list name ident all-keys))


### PR DESCRIPTION
This is the second in a series of pull-requests leading up to the implementation of a new version number scheme.  This also includes the commits from the first pull-request in the series; discuss those at #66.

The changes in these commits are not *required* to implement the new version number scheme.  However, changing *how we determine* the commit to be packaged, and what version string we use to identify that package, are related.

Both of these changes (can) lead to version strings decreasing, so it seems like a good idea to merge them at the same time.  I therefore that we do not merge this into `master` before we merge the new version number scheme, and that we not even use it on Melpa itself.

But while related, these are separate changes, which should be discussed separately.

This commit fixes the issue raised in #61: in some edge-cases we do not identify the correct commit to build a package from.  Since these are edge-cases, we could ignore them, which would be appealing because fixing them results in a breaking change, but I think that now would be a good time to address them, along with the other big breaking change that is switching to a new version number scheme.

The change, including the trade offs are described in detail in the commit message:

```
Use git/hg to determine correct commit for snapshot

Before this commit we determined the files that match a package's
files-spec using an elisp implementation and then we used git/hg to
determine the latest commit in which one of these files was modified.
This had two issues:

1. It was necessary to check out the latest upstream commit as part
   of the commit selection step.

   This led to an unfortunate lack of separation of concerns, most
   of which were addressed in commits leading up to this one.

   The remaining lack of separation could be addressed by using a
   new elisp implementation, which operated on a git tree instead of
   on checked out files, but doing that would not address the second
   issue below.  Addressing that, would mean throwing out this new
   implementation in the very next commit, which is why this commit
   tackles these two issues at once.

2. The wrong commit was selected in at least the following edge-case:

   A first commit A touches a matching file.  A second commit B
   removes another matching file.  A third and final (HEAD) commit C
   doesn't modify any matching files, so no snapshot package is build
   for that commit.

   Never-the-less C is used to determine what the matching files are
   and because the file that was removed in B, no longer exists in C
   we concluded that A was the last commit in which something relevant
   happened.  The removal of a matching file in B warrants a new
   snapshot based on that commit, but because HEAD is at C, we used
   to built a snapshot for A instead.

The second issue could be addressed in elisp alone, i.e., we could
walk all commits without relying on git and hg, but that would be
very inefficient and likely error-prone.

This commit separates concerns between elisp and git/hg differently.
`package-build--spec-globs' converts the files spec into arguments
understood by git or hg.  Git or hg then takes care of finding the
last commit that touched any matching file.  This includes removals
of matching files.

Unfortunately both git and hg process all include rules before all
exclude rules, i.e., they disregard the order of the arguments.
Previously it was possible to override the default exclude rules in
the recipe-specific files spec, but we have to give up on that.  In
practice this change affects very few packages, five to be precise,
but it *is* a change in behavior, and it is forced upon us by this
limitation in git and hg.

Determining the latest commit that touches any of the matching files
and actually listing the matching files in that commit are separate
tasks, which were always performed separately.  It would have been
nice to also rely on git resp. hg to do the latter, but unfortunately
that is not possible.

While git and hg match the same files as the elisp implementation
(modulo the exclude complication), they do not produce the same
output.  When a directory matches a glob, then they list all files
within that directory instead of the directory itself.  That makes
sense from their perspective, but is not what we need.  So we still
need `package-build--expand-files-spec' (and have to adjust it to
process includes before excludes, to match the git/hg behavior).
```

Speaking of `hg`, there is one more change I would like to discuss.  I have already added *optional* support for using `git-remote-hg` instead of `hg` directly to clone and pull Mercurial repositories. (`git-remote-hg` is an implementation of Git's "remote-helper" protocol, which allows interacting with foreign VCS using `git`.)

I would like to suggest that we use that for Melpa itself but keep support for using `hg` directly for functionality that *already exists*.  That would mean that I would not have to implement parts of the code required for by the new version number scheme twice.  We could still implement it for `hg` *eventually*, but not requiring this up front, would allow us to move faster.

I have used `git-remote-hg` on the Emacsmirror for years.  It works very reliably.  The only drawbacks are that it will have to be installed on the server and that the commit hashes we record are Git's hashes of the imported commits, not the hashes used by Mercurial itself.  The recorded hashes are mostly intended for internal purposes, so I would say this is not a big deal.  Also there are only 14 packages that use Mercurial.