### PR TITLE
fix(package-build.el): Don't check for file-executable-p

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -444,8 +444,7 @@ with a timeout so that no command can block the build process."
   "Return `bsd' or `gnu' depending on type of Tar executable.
 Tests and sets variable `package-build--tar-type' if not already set."
   (or package-build--tar-type
-      (when (and package-build-tar-executable
-                 (file-executable-p package-build-tar-executable))
+      (when package-build-tar-executable
         (setq package-build--tar-type
               (let ((v (shell-command-to-string
                         (format "%s --version" package-build-tar-executable))))


### PR DESCRIPTION
Having `(file-executable-p "tar")` wouldn't work, and it will always return `nil`.

We have two solutions,

1. Remove `file-executable-p` check
2. Use `(executable-find "tar")` while assigning value to `package-build-tar-executable`

```elisp
(defcustom package-build-tar-executable (executable-find "tar")
  ...
```