### PR TITLE
package-build--get-timestamp-version (hg): fix empty timestamp problem

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -302,9 +302,11 @@ Otherwise do nothing.  FORMAT-STRING and ARGS are as per that function."
       (list rev-hash rev-time))))
 
 (cl-defmethod package-build--get-timestamp-version ((rcp package-hg-recipe))
-  ;; TODO Respect commit and branch properties.
-  ;; TODO Use latest release if appropriate.
-  (package-build--select-commit rcp "." nil))
+  (let* ((commit (oref rcp commit))
+         (branch (or (oref rcp branch) "default"))
+         (rev (format "sort(ancestors(%s), -rev)"
+                      (or commit (format "max(branch(%s))" branch)))))
+    (package-build--select-commit rcp rev nil)))
 
 ;;; Run Process
 


### PR DESCRIPTION
# Fix Empty Timestamp Problem, Respect commit Property

The problem with

``` sh
hg log --limit 1  --rev . -- --include glob:file.el
```

is that it results in an empty string, if the referenced commit does not
contain a diff for any of the specified files.

Disclaimer: This pull request is meant to illustrate a problem without
uttering a plethora of words (which I still do). It is not meant to be
the ultimate solution to a problem and the pull request can certainly be
ignored, if there is a better way.

According to the documentation, "." is a special revision name, relating
to the state of the working directory

> The reserved name "." indicates the working directory parent. If no
> working directory is checked out, it is equivalent to null. If an
> uncommitted merge is in progress, "." is the revision of the first
> parent.

So IMHO using it for the purpose of a deterministic revision
identification is a really bad idea.

Especially, since it defaults to *null* without a working directory,
which automatically results in a 0 timestamp in all cases with a glob
pattern, since revision null obviously never contains any diffs.

Even specifying *tip* with a glob pattern results in a blank line, if
the latest commit does not contain a diff for any of the matched files.

Therefore, no revision should be specified at all, if a glob pattern is
given.

When a specific commit is referenced, the glob pattern does not change
the outcome, since diffs in the commit do not get a separate timestamp.
However, if the glob pattern does not match any diff in the commit,
again a blank line is delivered.

In the following example, revision *tip* contains a diff for <span class="title-ref">dist-selpa.sh</span>, but no diff for <span class="title-ref">README.txt</span>.
The commit <span class="title-ref">53fb5b8676e6</span> contains a diff for <span class="title-ref">README.txt</span>,  but no diff for <span class="title-ref">dist-selpa.sh</span>.

``` sh
(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev null )
0000000000000000000000000000000000000000 0 0
(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev null -- --include glob:dist-selpa.sh --include glob:README.txt )
<BLANKLINE>

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev tip -- --include glob:dist-selpa.sh --include glob:README.txt )
e4c502bddd4fcf14776b5ebd43c69a5b30974de3 1679001444 -3600

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev tip -- --include glob:README.txt )
<BLANKLINE>

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' -- --include glob:dist-selpa.sh --include glob:README.txt )
e4c502bddd4fcf14776b5ebd43c69a5b30974de3 1679001444 -3600

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' -- --include glob:README.txt )
53fb5b8676e62339ee68137f888a77220aad6ccc 1678853918 -3600

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev 53fb5b8676e6 -- --include glob:dist-selpa.sh )
<BLANKLINE>

(cd /home/ws/project/unorg/ && hg log --limit 1 --template '{node} {date|hgdate}\n' --rev 53fb5b8676e6 )
53fb5b8676e62339ee68137f888a77220aad6ccc 1678853918 -3600
```

Based on these findings, the algorithm implemented does the following in
the given order:

1.  In *package-build--get-timestamp-version (hg)* pass on *commit*
    property to <span class="title-ref">package-build--select-commit
    (hg)</span>
2.  in *package-build--select-commit*, use option
    <span class="title-ref">--rev</span> only, when the *rev* parameter
    is not nil. If the revision does not exist, an error is thrown.
3.  Otherwise, get the timestamp for the latest commit containing a diff
    for one of the supplied glob patterns. If no commit matches, a blank
    line is returned.
4.  Without a revision or glob pattern, the latest timestamp for the
    repository is obtained. If the repository is empty, a blank line is
    returned.
5. if a blank line is returned, "0 0 0" is substituted.