### PR TITLE
Remove superfluous quote in generation of elpa-packages.eld

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -1094,7 +1094,7 @@ If optional PRETTY-PRINT is non-nil, then pretty-print
           (newline)
           (insert "  ")
           (prin1 entry (current-buffer)))
-        (insert ")\n :version 1 :default-vc 'Git)\n")))
+        (insert ")\n :version 1 :default-vc Git)\n")))
     entries))
 
 (defun package-build--remove-archive-files (archive-entry)


### PR DESCRIPTION
The code that generates the `elpa-packages.eld` file currently quotes the `Git` symbol in the `:default-vc` setting.
I am pretty sure this is incorrect and the symbol should be unquoted.