### PR TITLE
Implement new version scheme for snapshot channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.elc
+/*-autoloads.el
+/config.mk

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
 -include config.mk
 include default.mk
 
+.PHONY: test
+
 all: lisp
 
 help:
 	$(info make all          - generate byte-code and autoloads)
 	$(info make lisp         - generate byte-code and autoloads)
+	$(info make test         - run tests)
+	$(info make demo         - run tests showing their documentation)
 	$(info make clean        - remove generated files)
 	@printf "\n"
 
 lisp: $(ELCS) loaddefs check-declare
+	@$(MAKE) -C test lisp
 
 loaddefs: $(PKG)-autoloads.el
 
@@ -22,7 +27,13 @@ check-declare:
 	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) \
 	--eval "(check-declare-directory default-directory)"
 
-CLEAN  = $(ELCS) $(PKG)-autoloads.el
+test:
+	@$(MAKE) -C test test
+
+demo:
+	@$(MAKE) -C test demo
+
+CLEAN = $(ELCS) $(PKG)-autoloads.el test/$(PKG)-tests.elc
 
 clean:
 	@printf " Cleaning...\n"

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,11 @@
 -include config.mk
-
-PKG = package-build
-
-ELS   = package-recipe.el
-ELS  += package-build-badges.el
-ELS  += $(PKG).el
-ELS  += package-recipe-mode.el
-ELCS  = $(ELS:.el=.elc)
-
-DEPS  =
-
-EMACS      ?= emacs
-EMACS_ARGS ?=
-
-LOAD_PATH  ?= $(addprefix -L ../,$(DEPS))
-LOAD_PATH  += -L .
+include default.mk
 
 all: lisp
 
 help:
-	$(info make [all|lisp]   - generate byte-code and autoloads)
+	$(info make all          - generate byte-code and autoloads)
+	$(info make lisp         - generate byte-code and autoloads)
 	$(info make clean        - remove generated files)
 	@printf "\n"
 

--- a/default.mk
+++ b/default.mk
@@ -1,0 +1,21 @@
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))
+
+PKG = package-build
+
+ELS   = package-recipe.el
+ELS  += package-build-badges.el
+ELS  += package-build.el
+ELS  += package-recipe-mode.el
+ELCS  = $(ELS:.el=.elc)
+
+DEPS  =
+
+VERSION ?= $(shell test -e $(TOP).git && git describe --tags --abbrev=0 | cut -c2-)
+
+EMACS      ?= emacs
+EMACS_ARGS ?=
+
+LOAD_PATH  ?= $(addprefix -L $(TOP)../,$(DEPS))
+LOAD_PATH  += -L $(TOP)
+
+BATCH       = $(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH)

--- a/package-build-badges.el
+++ b/package-build-badges.el
@@ -32,7 +32,6 @@
 
 ;;; Code:
 
-(defvar package-build-stable)
 (defvar package-build-badge-data)
 
 (defun package-build--write-badge-image ( name version target-dir
@@ -40,9 +39,9 @@
   "Make badge svg file.
 This is essentially a copy of `elpaa--make-badge'."
   (let* ((file (expand-file-name (concat name "-badge.svg") target-dir))
-         (left (or archive (car package-build-badge-data)))
+         (left (or archive (car package-build-badge-data) "myElpa"))
          (right (url-hexify-string version))
-         (color (or color (cadr package-build-badge-data)))
+         (color (or color (cadr package-build-badge-data) "#ff491b"))
          (lw (package-build-badge--string-width left))
          (rw (package-build-badge--string-width right))
          (pad (package-build-badge--string-width "x"))

--- a/package-build.el
+++ b/package-build.el
@@ -206,22 +206,15 @@ similar, which will provide the GNU timeout program as
 Can be `gnu' or `bsd'; nil means the type is not decided yet.")
 
 (define-obsolete-variable-alias 'package-build-write-melpa-badge-images
-  'package-build-write-badge-images "Package-Build 5.0.0")
+  'package-build-badge-data "Package-Build 5.0.0")
 
-(defcustom package-build-write-badge-images nil
-  "When non-nil, write badge images alongside packages.
-These badges can, for example, be used on GitHub pages."
-  :group 'package-build
-  :type 'boolean)
+(defcustom package-build-badge-data nil
+  "Text and color used in badge images, if any.
 
-(defcustom package-build-badge-data
-  (if package-build-stable
-      (list "melpa stable" "#3e999f")
-    (list "melpa" "#922793"))
-  "Data used when generating badge images.
-The default value is set based on `package-build-stable'.
-`package-build-write-badge-images' controls whether images
-are generated."
+If nil (the default), then no badge images are generated,
+otherwise this has the form (NAME COLOR).  MELPA sets the value
+in its top-level Makefile, to different values, depending on the
+channel that is being build."
   :group 'package-build
   :type '(list (string :tag "Archive name") color))
 
@@ -1014,7 +1007,7 @@ in `package-build-archive-dir'."
               (package-build--build-single-file-package rcp files))
              (t
               (package-build--build-multi-file-package rcp files)))
-            (when package-build-write-badge-images
+            (when package-build-badge-data
               (package-build--write-badge-image
                (oref rcp name) (oref rcp version) package-build-archive-dir))))
       (funcall package-build-cleanup-function rcp))))

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,27 @@
+-include ../config.mk
+include ../default.mk
+
+test:
+	@export MELPA_BASE=$$(mktemp -d) && \
+	$(BATCH) --eval "(progn\
+	(setq package-build--melpa-base \"$$MELPA_BASE\")\
+	(load-file \"$(TOP)test/package-build-tests.el\")\
+	(ert-run-tests-batch-and-exit))" && \
+	rm -rf "$$MELPA_BASE"
+
+demo:
+	@export MELPA_BASE=$$(mktemp -d) && \
+	PB_TEST_VERBOSE=true $(BATCH) --eval "(progn\
+	(setq package-build--melpa-base \"$$MELPA_BASE\")\
+	(load-file \"$(TOP)test/package-build-tests.el\")\
+	(ert-run-tests-batch-and-exit))" && \
+	rm -rf "$$MELPA_BASE"
+
+lisp: package-build-tests.elc
+
+%.elc: %.el
+	@printf "Compiling $<\n"
+	@$(BATCH) --eval "(progn\
+	(when (file-exists-p \"$@\")\
+	  (delete-file \"$@\")))" \
+	-f batch-byte-compile $<

--- a/test/package-build-tests.el
+++ b/test/package-build-tests.el
@@ -1,0 +1,301 @@
+;;; package-build-tests.el --- Tests for Package-Build  -*- lexical-binding:t -*-
+
+;; Copyright (C) 2023 Jonas Bernoulli
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; Magit is free software: you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+
+(require 'package-build)
+
+(defmacro package-build-test-package (&rest body)
+  (declare (indent 0) (debug t))
+  `(let* ((package-build-verbose nil)
+          (package-build-fetch-function #'ignore)
+          (package-build-checkout-function #'ignore)
+          (package-build-stable nil)
+          (package-build-snapshot-version-functions
+           (list #'package-build-release+count-version))
+          (package-build-release-version-functions
+           (list #'package-build-tag-version))
+          (test (ert-running-test))
+          (name (symbol-name (ert-test-name test)))
+          (_ (string-match "\\`package-build-test-\\([0-9]+\\)-\\(.+\\)" name))
+          (num  (match-string 1 name))
+          (desc (match-string 2 name))
+          (package-build-working-dir
+           (file-name-as-directory
+            (expand-file-name num package-build-working-dir)))
+          (elpa-n ?A)
+          (verbose (member (getenv "PB_TEST_VERBOSE") '("t" "true"))))
+     (when verbose
+       (message "\n=== %s %s ===\n\n%s\n" num desc
+                (replace-regexp-in-string
+                 "^" "  " (ert-test-documentation test))))
+     (make-directory package-build-working-dir t)
+     (make-directory package-build-archive-dir t)
+     (make-directory package-build-recipes-dir t)
+     (with-temp-file (expand-file-name "pkg" package-build-recipes-dir)
+       (insert "(pkg :fetcher git :url \"https://example.com\")\n"))
+     (cl-flet* ((git (&rest args)
+                  (with-temp-buffer
+                    (unless (zerop (apply #'call-process "git" nil t nil args))
+                      (error "%s" (buffer-string)))
+                    (buffer-string)))
+                (tag (&rest args)
+                  (apply #'git "tag" "--no-sign" "--force" args))
+                (rec (msg &optional file &rest args)
+                  (git "add" (or file "."))
+                  (let ((process-environment
+                         (copy-sequence process-environment)))
+                    (setenv "GIT_AUTHOR_NAME" "abc")
+                    (setenv "GIT_AUTHOR_EMAIL" "a@b.c")
+                    (setenv "GIT_AUTHOR_DATE" "1970-01-01T00:00:00Z")
+                    (setenv "GIT_COMMITTER_NAME" "abc")
+                    (setenv "GIT_COMMITTER_EMAIL" "a@b.c")
+                    (setenv "GIT_COMMITTER_DATE" "1970-01-01T00:00:00Z")
+                    (apply #'git "commit" "--allow-empty" "-m" msg args))
+                  (git "update-ref" "refs/remotes/origin/main" "main"))
+                (mod (file &optional content msg)
+                  (with-temp-file file
+                    (when content
+                      (insert content "\n"))
+                    (when (equal file "pkg.el")
+                      (insert "(require 'pkg)\n")))
+                  (when msg
+                    (rec msg file)))
+                (reset (rev)
+                  (git "reset" "--hard" rev)
+                  (git "update-ref" "refs/remotes/origin/main" "main"))
+                (build ()
+                  (when verbose
+                    (message "Building from %s/working/%s/pkg"
+                             package-build--melpa-base num))
+                  (package-build-archive "pkg" t))
+                (check (version commit &optional silent)
+                  (when (zerop (call-process "git" nil t nil
+                                             "rev-parse" "--verify" commit))
+                    (tag (format "elpa_%c__%s" elpa-n version) commit))
+                  (setq elpa-n (1+ elpa-n))
+                  (when (and (not silent) verbose)
+                    (message
+                     "\n%s"
+                     (git "log" "--oneline" "--graph" "--color"
+                          ;; "--no-abbrev-commit"
+                          "--branches" "--tags" "--decorate"
+                          "--decorate-refs-exclude=HEAD"
+                          "--decorate-refs-exclude=refs/heads/main"
+                          "--decorate-refs-exclude=refs/remotes/origin/HEAD")))
+                  (let ((elt (cdr (assq 'pkg (package-build-archive-alist)))))
+                    (should (equal (cdr (assq :commit (aref elt 4))) commit))
+                    (should (equal (package-version-join (aref elt 0))
+                                   version))))
+                (run (version commit &optional silent)
+                  (build)
+                  (check version commit silent)))
+       (let ((wtree (expand-file-name "pkg" package-build-working-dir)))
+         (git "init" "-b" "main" wtree)
+         (let ((default-directory wtree))
+           (mod "pkg.el" nil "Initial import")
+           (git "symbolic-ref"
+                "refs/remotes/origin/HEAD"
+                "refs/remotes/origin/main")
+           ,@body)))))
+
+(ert-deftest package-build-test-001-use-latest-relevant-commit ()
+  "Base the snapshot version string on the greatest release tag.
+
+Determine the last reachable commit that touches a file that we
+want to include in packages.  Skip over commits that touch only
+files that are not included.  By doing so, we avoid building new
+snapshots that are identical to the previous snapshot, except for
+the version string.
+
+Then determine the greatest release tag, while ignoring whether
+that is an ancestor of the selected commit.  (Below we will look
+into what it means, if that is not the case, but for now assume
+it is.)
+
+The snapshot version string has the format \"VERSION.0.COUNT\".
+VERSION is the version string derived from the selected tag and
+COUNT is the number of commits from that tag to the selected
+commit.
+
+Inject the \"separator\" \".0\" inbetween the VERSION and the
+COUNT to sufficiently decrease the odds that the version for a
+future release is smaller than the version for this snapshot.
+
+(Ideally Emacs would not only support \"pre-releases\" but also
+\"post-releases\".  If that were the case, we could use something
+like \"1.0-git42\", for a commit that comes 42 commits after the
+tag \"1.0\".  But as it is implemented in `version<' et al.,
+\"1.0-git\" is actually smaller than \"1.0\".)
+
+Injecting one \".0\" is both necessary and sufficient.  Just
+because the last release is \"1.0\", we cannot be sure that the
+next release will be either \"2.0\" or \"1.1\".  It might also be
+\"1.0.1\".  By using \"1.0.0.COUNT\" instead of just
+\"1.0.COUNT\", we nearly ensure that that any potential future
+release is smaller than the snapshot.  Of course the next release
+after \"1.0\" could also be \"1.0.0.1\" (or \"1.0.0.0.0.0.1\" for
+that matter) but that is much less likely.
+
+(We could use the separator \".1-snapshot\" to be absolutely sure
+that a future release is always greater than a snapshot, but that
+is disgustingly long.  Note that we could not use the shorter
+\".0-git\" because `version-to-list' encodes both -snapshot and
+-git as -4, and `package-version-join' turns -4 into -snapshot.)"
+  (package-build-test-package
+    (tag "1.0.0")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (mod "other" "b" "Add other")
+    (run "1.0.0.0.1" "5cae135f5352549a5b989c2ca8f3a3a38268c12a")))
+
+(ert-deftest package-build-test-002-dont-append-count-when-using-tag ()
+  "When the latest relevant commit is a tagged release, then use
+that version without appending a commit count."
+  (package-build-test-package
+    (tag "1.0.0")
+    (mod "other" "b" "Add other")
+    (run "1.0.0" "ded491870604ef18249181b96e54396a849da707")))
+
+(ert-deftest package-build-test-003-dont-go-past-tag ()
+  "If the latest commit that modifies a relevant file is an ancestor
+of the latest release tag (as opposed to the other way around),
+then use the release commit, because the version on the snapshot
+channel should never be older than the version on the release
+channel."
+  (package-build-test-package
+    (tag "1.0.0")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (rec "Release 1.0.1 without changes")
+    (tag "1.0.1")
+    (mod "other" "b" "Add other")
+    (run "1.0.1" "b208dc6b8343dd95a07cbb97142351b9426bac20")))
+
+(ert-deftest package-build-test-004-use-zeros-if-no-tag ()
+  "If there is no release tag, use two zero parts before the
+separator zero part and count part.  In this case the count is
+the total number of commit, reachable from the selected commit.
+
+So, if there are no tags, then the count part is always prefixed
+with exactly three zero parts.  If the package author later uses
+\"0.0.1\" as the first tag, then that is larger than existing
+snapshots.  However if they begin with \"0.0.0.1\", then that is
+not the case.  We have to draw the line somewhere and, IMO, if it
+matters at all whether a certain release is used or not, then the
+first bumped part of the version string should not be the
+sub-sub-minor-part (this applies to the first release, but also
+future version bumps)."
+  (package-build-test-package
+    (mod "other" "b" "Add other")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (run "0.0.0.3" "3ce2b15e048169dcc4193c18b5589bc90c60a32b")))
+
+(ert-deftest package-build-test-005-count-since-merge-base ()
+  "Sometimes release are made on dedicated release branches, and
+sometimes these release branches are not merged back into the
+development branch, immediately or at all.
+
+If that happens, we cannot count the commits from the tag to the
+latest relevant commit.  Instead we count the commits from the
+the merge-base of the selected commit and the selected tag.  The
+merge-base is the last common ancestor of two commits."
+  (package-build-test-package
+    (mod "other" "b" "Add other")
+    (git "checkout" "-b" "releases" "HEAD~")
+    (rec "Release 1.0.0")
+    (tag "1.0.0")
+    (git "checkout" "main")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (run "1.0.0.0.2" "3ce2b15e048169dcc4193c18b5589bc90c60a32b")))
+
+(ert-deftest package-build-test-006-merge-base-required ()
+  "Due to extremely sloppy history rewritting, it is possible that
+tags share no history at all with the branches that still exist
+in the repository.  This is the result of an upstream mistake,
+and it is not our job to fix it.  Again, we have to draw the line
+somewhere.
+
+So, if the greatest release tag shares no history with the
+tracked branch, then we pretend there are no tags at all.  (We
+could instead ignore that tag and use the next greatest release
+tag, which actually shares some history, if any, but IMO that
+would be even more confusing to users.)"
+  (package-build-test-package
+    (tag "6.0.0")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (git "checkout" "--orphan" "detached")
+    (rec "A root commit")
+    (tag "6.0.1")
+    (git "checkout" "main")
+    ;; Pretend there are no tags.
+    (run "0.0.0.2" "5cae135f5352549a5b989c2ca8f3a3a38268c12a")
+    ;; Ignore orphan tags (here 6.0.1), but not other tags (6.0.0).
+    ;; (run "6.0.0.1" "5cae135f5352549a5b989c2ca8f3a3a38268c12a")
+    ))
+
+(ert-deftest package-build-test-007-amending-adds-count-part ()
+  "If HEAD is amended, add an additional count version part."
+  (package-build-test-package
+    (tag "7.0")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (run "7.0.0.1" "5cae135f5352549a5b989c2ca8f3a3a38268c12a" t)
+    (rec "Edit pkg.el (modified)" nil "--amend")
+    (run "7.0.0.1.1" "6d26f69fa2fa150d12b0b485b6f3e5f4948151fe")))
+
+(ert-deftest package-build-test-008-dropping-adds-count-part ()
+  "If HEAD is removed, add an additional count version part."
+  (package-build-test-package
+    (tag "8.0.0")
+    (mod "pkg.el" "a" "Edit pkg.el")
+    (mod "pkg.el" "b" "Edit pkg.el (will be dropped)")
+    (run "8.0.0.0.2" "f138089d7313b60a729f75c5bb235fb6a2911ba9" t)
+    (reset "HEAD~")
+    (run "8.0.0.0.2.1" "5cae135f5352549a5b989c2ca8f3a3a38268c12a")))
+
+(ert-deftest package-build-test-009-dropping-adds-count-part ()
+  "Accumulate and shed smaller count parts.  The previous snapshot
+may have multiple count parts.  Compare the new count with the
+last of these.  If the new count is smaller than the last count,
+then append the new count.  Otherwise remove the old count part.
+Continue this process for preceeding count parts until there are
+none left, or it is larger than the new count."
+  (package-build-test-package
+    (tag "1.0")
+    (mod "pkg.el" "1" "1")
+    (mod "pkg.el" "2" "2")
+    (mod "pkg.el" "3" "3")
+    (run "1.0.0.3" "313e86cfc8aea39b8eb2a5be15adf116eed6cce4" t)
+    (reset "HEAD~")
+    (mod "pkg.el" "4" "4")
+    (run "1.0.0.3.3" "433ebf7c7586514389036ed2af449e00df54a2b8" t)
+    (reset "HEAD~3")
+    (mod "pkg.el" "5" "5")
+    (run "1.0.0.3.3.1" "323cbd45df8b333689b9b5e7e0c5ff469b39b564" t)
+    (reset "HEAD~1")
+    (mod "pkg.el" "6" "6")
+    (mod "pkg.el" "7" "7")
+    (run "1.0.0.3.3.2" "43d78a452ad43a3ab4a603258779b95a028122fb" t)
+    (reset "HEAD~1")
+    (mod "pkg.el" "8" "8")
+    (mod "pkg.el" "9" "9")
+    (mod "pkg.el" "A" "A")
+    (run "1.0.0.4" "5f141cefedd3f0104eb5ba6bda090ea9187adc01")))
+
+;;; package-build-tests.el ends here


### PR DESCRIPTION
A lot has been said about why the version string format that Melpa uses for its snapshot channel, has to be replaced.  I won't repeat all that here, but consider:

    (version< "109.0" "19700101.0") => t

Some of the related conversations:

- 2015-07 melpa/melpa#2944
- 2015-07 melpa/melpa#2955
- 2019-06 melpa/melpa#6319
- 2020-01 melpa/melpa#6656
- 2022-07 melpa/melpa#8135
- 2022-11 melpa/package-build#65

----

Add three new functions to generate version strings for the snapshot channel of an Emacs Lisp package archive:

1. `package-build-get-tag+timestamp-version` creates version string using the format `VERSION.0.TIMESTAMP`, where VERSION derives from the largest version tag.  TIMESTAMP is the COMMITTER-DATE for the identified last relevant commit, using the format `%Y%m%d.%H%M`.

2. `package-build-get-tag+count-unsafe-version` creates version strings using the format `VERSION.0.COUNT`, where VERSION derives from the largest version tag.  COUNT is the number of commits since that tag until the identified last relevant commit.

3. `package-build-get-tag+count-version` creates version strings using the same format `VERSION.0.COUNT`, but if upstream rewrites history, then COUNT may consist of multiple version parts.  This is what we should use on MELPA.

The `.0` separator between the version, based on the tag, and the part that identifies the commit for which a snapshot is build, is necessary because Emacs only supports "pre-releases" but not "post-releases".

If "post-releases" were supported, then we could use something like "1.0-42" or "1.0-20230413.123", and those snapshot versions would be both larger than "1.0" and smaller than "1.0.1".

But `version<` et al. actually treat these version strings (as well as "1.0-git42" and "1.0-snapshot") as smaller than "1.0", i.e., they are "pre-releases", not "post-releases".

    (version< "1.0-42" "1.0") => t

Simply injecting an additional `.0` part doesn't change that:

    (version< "1.0.0-42" "1.0") => t

So we have to give up on being able to tell with absolute certainty whether a given version strings identifies a release or a snapshot:

    (version< "1.0" "1.0.42") => t

But this is problematic.  Just because the version string for the current release has two parts (`1.0`), that does not guarantee that the next release will have two parts too (either `1.1` or `2.0`).  It might also be `1.0.1`.  We get around that by injecting an additional `.0`.

    1.0 < 1.0.0.42 < 1.0.1

Of course the next release after `1.0` could also be `1.0.0.1`, but that is much less likely, so we stick with just one separator `.0`. (We are stuck between a rock and a hard place, Emacs' unfortunate version comparison implementation and maintainers potentially doing weird things; and there is only so much we can do to cope.)

So we go with version strings of the format `VERSION.0.SNAPSHOT`, and now the question is how we determine `SNAPSHOT`.

We can just use the committer date of the commit.  That is what GNU-devel ELPA and NonGNU-devel ELPA do.  The main problem with that approach is that it leads to very long version strings.  Additionally it cannot guarantee that version strings increase, in case upstream rewrites history.

    VERSION.0.TIMESTAMP

Simply starting with `1` and increasing it by `1` every time we build a new snapshot, is also an option.  The resulting version string is short and we can be sure versions keep going up.

    VERSION.0.N

But `N` is not particularly meaningful.

Fortunately there is an alternative; use the `COUNT` of commits since the last VERSION.

    VERSION.0.COUNT

Like TIMESTAMP, COUNT communicates some information beyond "this is a snapshot, not a release".  It isn't the same information though; IMO it is more useful information.  For example, if TIMESTAMP is a fairly long time ago, then we have no way of knowing whether the maintainer just fixed a single inconsequential typo, or whether there are many changes.  A commit count like `123` however, is a clear indication that a lot has happened since the last release.

Like TIMESTAMP, using COUNT is problematic when upstream rewrites history.  Rewriting history itself is problematic -- some would say wrong.  While I would not go that far, as someone who does at times amend to HEAD or drop HEAD even on the main branch, I am aware that that can have negative consequences.  I therefore accept that it is me who should suffer the consequences -- not those who do the right thing, or the users of my packages.

In this context this means that we should optimize for repositories that do not get rewritten.  We do that by just using the new count by default.  If it is larger than the last count and everything is peachy, and that is what we optimize for.

When the count does *not* increase due to history rewriting, then we should make an effort to relieve the users' suffering.  And the maintainer has to pay the price, by getting a version string for their snapshot, which is uglier than the normal version string of well-behaved repositories.

Doing that is simple.  If the new count is smaller than the old count, then we don't replace the old count, instead we append the new count. For example, if upstream drops HEAD, then the version string gets increase like so:

    1.0.0.42  -->  1.0.0.42.41

There are various edge-cases that need to be considered.  I have written tests for those, and have additionally added a make target named "demo", which extends the tests to output documentation and git logs, to demonstrate what those edge-cases are and how we deal with them.

    make demo

For convenience, I am including its output here:

<details>

```
make[1]: Entering directory '/home/jonas/.config/emacs/lib/package-build/test'
Loading /home/jonas/.config/emacs/lib/package-build/test/package-build-tests.el (source)...
Running 9 tests (2023-04-18 10:46:45+0200, selector ‘t’)

=== 001 use-latest-relevant-commit ===

  Base the snapshot version string on the greatest release tag.
  
  Determine the last reachable commit that touches a file that we
  want to include in packages.  Skip over commits that touch only
  files that are not included.  By doing so, we avoid building new
  snapshots that are identical to the previous snapshot, except for
  the version string.
  
  Then determine the greatest release tag, while ignoring whether
  that is an ancestor of the selected commit.  (Below we will look
  into what it means, if that is not the case, but for now assume
  it is.)
  
  The snapshot version string has the format "VERSION.0.COUNT".
  VERSION is the version string derived from the selected tag and
  COUNT is the number of commits from that tag to the selected
  commit.
  
  Inject the "separator" ".0" inbetween the VERSION and the
  COUNT to sufficiently decrease the odds that the version for a
  future release is smaller than the version for this snapshot.
  
  (Ideally Emacs would not only support "pre-releases" but also
  "post-releases".  If that were the case, we could use something
  like "1.0-git42", for a commit that comes 42 commits after the
  tag "1.0".  But as it is implemented in `version<' et al.,
  "1.0-git" is actually smaller than "1.0".)
  
  Injecting one ".0" is both necessary and sufficient.  Just
  because the last release is "1.0", we cannot be sure that the
  next release will be either "2.0" or "1.1".  It might also be
  "1.0.1".  By using "1.0.0.COUNT" instead of just
  "1.0.COUNT", we nearly ensure that that any potential future
  release is smaller than the snapshot.  Of course the next release
  after "1.0" could also be "1.0.0.1" (or "1.0.0.0.0.0.1" for
  that matter) but that is much less likely.
  
  (We could use the separator ".1-snapshot" to be absolutely sure
  that a future release is always greater than a snapshot, but that
  is disgustingly long.  Note that we could not use the shorter
  ".0-git" because `version-to-list' encodes both -snapshot and
  -git as -4, and `package-version-join' turns -4 into -snapshot.)

Building from /tmp/tmp.PjqoU8zNCg/working/001/pkg
Built pkg in 0.043s, finished at 2023-04-18T08:46:45+0000

* 899b661 (origin/main) Add other
* 5cae135 (tag: elpa_A__1.0.0.0.1) Edit pkg.el
* ded4918 (tag: 1.0.0) Initial import

   passed  1/9  package-build-test-001-use-latest-relevant-commit (0.214680 sec)

=== 002 dont-append-count-when-using-tag ===

  When the latest relevant commit is a tagged release, then use
  that version without appending a commit count.

Building from /tmp/tmp.PjqoU8zNCg/working/002/pkg
Built pkg in 0.105s, finished at 2023-04-18T08:46:45+0000

* fbc9cd6 (origin/main) Add other
* ded4918 (tag: elpa_A__1.0.0, tag: 1.0.0) Initial import

   passed  2/9  package-build-test-002-dont-append-count-when-using-tag (0.231762 sec)

=== 003 dont-go-past-tag ===

  If the latest commit that modifies a relevant file is an ancestor
  of the latest release tag (as opposed to the other way around),
  then use the release commit, because the version on the snapshot
  channel should never be older than the version on the release
  channel.

Building from /tmp/tmp.PjqoU8zNCg/working/003/pkg
Built pkg in 0.035s, finished at 2023-04-18T08:46:45+0000

* f482a81 (origin/main) Add other
* b208dc6 (tag: elpa_A__1.0.1, tag: 1.0.1) Release 1.0.1 without changes
* 5cae135 Edit pkg.el
* ded4918 (tag: 1.0.0) Initial import

   passed  3/9  package-build-test-003-dont-go-past-tag (0.122652 sec)

=== 004 use-zeros-if-no-tag ===

  If there is no release tag, use two zero parts before the
  separator zero part and count part.  In this case the count is
  the total number of commit, reachable from the selected commit.
  
  So, if there are no tags, then the count part is always prefixed
  with exactly three zero parts.  If the package author later uses
  "0.0.1" as the first tag, then that is larger than existing
  snapshots.  However if they begin with "0.0.0.1", then that is
  not the case.  We have to draw the line somewhere and, IMO, if it
  matters at all whether a certain release is used or not, then the
  first bumped part of the version string should not be the
  sub-sub-minor-part (this applies to the first release, but also
  future version bumps).

Building from /tmp/tmp.PjqoU8zNCg/working/004/pkg
Built pkg in 0.024s, finished at 2023-04-18T08:46:45+0000

* 3ce2b15 (tag: elpa_A__0.0.0.3, origin/main) Edit pkg.el
* fbc9cd6 Add other
* ded4918 Initial import

   passed  4/9  package-build-test-004-use-zeros-if-no-tag (0.083377 sec)

=== 005 count-since-merge-base ===

  Sometimes release are made on dedicated release branches, and
  sometimes these release branches are not merged back into the
  development branch, immediately or at all.
  
  If that happens, we cannot count the commits from the tag to the
  latest relevant commit.  Instead we count the commits from the
  the merge-base of the selected commit and the selected tag.  The
  merge-base is the last common ancestor of two commits.

Building from /tmp/tmp.PjqoU8zNCg/working/005/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:45+0000

* 3ce2b15 (tag: elpa_A__1.0.0.0.2, origin/main) Edit pkg.el
* fbc9cd6 Add other
| * c58e60c (tag: 1.0.0, releases) Release 1.0.0
|/  
* ded4918 Initial import

   passed  5/9  package-build-test-005-count-since-merge-base (0.116674 sec)

=== 006 merge-base-required ===

  Due to extremely sloppy history rewritting, it is possible that
  tags share no history at all with the branches that still exist
  in the repository.  This is the result of an upstream mistake,
  and it is not our job to fix it.  Again, we have to draw the line
  somewhere.
  
  So, if the greatest release tag shares no history with the
  tracked branch, then we pretend there are no tags at all.  (We
  could instead ignore that tag and use the next greatest release
  tag, which actually shares some history, if any, but IMO that
  would be even more confusing to users.)

Building from /tmp/tmp.PjqoU8zNCg/working/006/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:45+0000

* 6663edd (tag: 6.0.1, detached) A root commit
* 5cae135 (tag: elpa_A__0.0.0.2, origin/main) Edit pkg.el
* ded4918 (tag: 6.0.0) Initial import

   passed  6/9  package-build-test-006-merge-base-required (0.106321 sec)

=== 007 amending-adds-count-part ===

  If HEAD is amended, add an additional count version part.

Building from /tmp/tmp.PjqoU8zNCg/working/007/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:45+0000
Building from /tmp/tmp.PjqoU8zNCg/working/007/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000

* 6d26f69 (tag: elpa_B__7.0.0.1.1, origin/main) Edit pkg.el (modified)
| * 5cae135 (tag: elpa_A__7.0.0.1) Edit pkg.el
|/  
* ded4918 (tag: 7.0) Initial import

   passed  7/9  package-build-test-007-amending-adds-count-part (0.138854 sec)

=== 008 dropping-adds-count-part ===

  If HEAD is removed, add an additional count version part.

Building from /tmp/tmp.PjqoU8zNCg/working/008/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000
Building from /tmp/tmp.PjqoU8zNCg/working/008/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000

* f138089 (tag: elpa_A__8.0.0.0.2) Edit pkg.el (will be dropped)
* 5cae135 (tag: elpa_B__8.0.0.0.2.1, origin/main) Edit pkg.el
* ded4918 (tag: 8.0.0) Initial import

   passed  8/9  package-build-test-008-dropping-adds-count-part (0.146229 sec)

=== 009 dropping-adds-count-part ===

  Accumulate and shed smaller count parts.  The previous snapshot
  may have multiple count parts.  Compare the new count with the
  last of these.  If the new count is smaller than the last count,
  then append the new count.  Otherwise remove the old count part.
  Continue this process for preceeding count parts until there are
  none left, or it is larger than the new count.

Building from /tmp/tmp.PjqoU8zNCg/working/009/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000
Building from /tmp/tmp.PjqoU8zNCg/working/009/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000
Building from /tmp/tmp.PjqoU8zNCg/working/009/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000
Building from /tmp/tmp.PjqoU8zNCg/working/009/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000
Building from /tmp/tmp.PjqoU8zNCg/working/009/pkg
Built pkg in 0.036s, finished at 2023-04-18T08:46:46+0000

* 5f141ce (tag: elpa_E__1.0.0.4, origin/main) A
* 2ac5f45 9
* 5ea956f 8
| * 313e86c (tag: elpa_A__1.0.0.3) 3
| | * 433ebf7 (tag: elpa_B__1.0.0.3.3) 4
| |/  
| * d61b8f9 2
| * 54bab6d 1
| | * 323cbd4 (tag: elpa_C__1.0.0.3.3.1) 5
| |/  
| | * 43d78a4 (tag: elpa_D__1.0.0.3.3.2) 7
| |/  
|/|   
* | 296e97d 6
|/  
* ded4918 (tag: 1.0) Initial import

   passed  9/9  package-build-test-009-dropping-adds-count-part (0.402664 sec)

Ran 9 tests, 9 results as expected, 0 unexpected (2023-04-18 10:46:46+0200, 1.563899 sec)

make[1]: Leaving directory '/home/jonas/.config/emacs/lib/package-build/test'
```

</details>