### PR TITLE
fix(package-build.el): Resolve all select coding system on Windows

### DIFF
--- a/package-build.el
+++ b/package-build.el
@@ -1022,6 +1022,7 @@ Use a sandbox if `package-build--use-sandbox' is non-nil."
 (defun package-build--write-pkg-file (rcp dir)
   (pcase-let (((eieio name version summary dependencies) rcp))
     (with-temp-file (expand-file-name (format "%s-pkg.el" name) dir)
+      (set-buffer-file-coding-system 'utf-8)
       (insert ";; -*- no-byte-compile: t; lexical-binding: nil -*-\n")
       (insert (format "(define-package \"%s\" \"%s\"\n" name version))
       (insert (format "  %s\n" (prin1-to-string (concat summary "."))))
@@ -1772,6 +1773,7 @@ If optional PRETTY-PRINT is non-nil, then pretty-print
                   vc-pkgs))))))
     (setq entries (cl-sort entries #'string< :key #'car))
     (with-temp-file (or file (expand-file-name "archive-contents"))
+      (set-buffer-file-coding-system 'utf-8)
       (let ((print-level nil)
             (print-length nil))
         (if pretty-print
@@ -1785,6 +1787,7 @@ If optional PRETTY-PRINT is non-nil, then pretty-print
     (setq vc-pkgs (cl-sort vc-pkgs #'string< :key #'car))
     (with-temp-file (expand-file-name "elpa-packages.eld"
                                       (and file (file-name-nondirectory file)))
+      (set-buffer-file-coding-system 'utf-8)
       (let ((print-level nil)
             (print-length nil))
         (insert "((")


### PR DESCRIPTION
Sorry, I wasn't very clear in my first PR #93. Let me try better this time. 😅 

---

I've recently encountered more `Select coding system (default utf-8): `prompts on Windows 11. 🤔 (The same as #70)

This patch tries to cover all possible places that could cause this bug.

Log: https://github.com/emacs-tree-sitter/tree-sitter-langs/actions/runs/20451954046/job/58766656622?pr=1272#step:9:36